### PR TITLE
Accessibility pass (#30)

### DIFF
--- a/astro-frontend/scripts/a11y-check.mjs
+++ b/astro-frontend/scripts/a11y-check.mjs
@@ -1,0 +1,58 @@
+// Automated accessibility check: runs axe-core against every route in the
+// running dev server using the already-installed Playwright + Edge. axe-core
+// is loaded from a CDN at runtime, so this adds no project dependency.
+//
+// Usage (with the dev server running on 127.0.0.1:4321):
+//   node scripts/a11y-check.mjs
+//
+// Exits non-zero if any route has violations.
+
+import { chromium } from 'playwright';
+
+const base = process.env.PREVIEW_URL ?? 'http://127.0.0.1:4321';
+const routes = [
+  '/',
+  '/skills',
+  '/education',
+  '/experience',
+  '/projects',
+  '/contacts',
+];
+const AXE_CDN =
+  'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.2/axe.min.js';
+
+const browser = await chromium.launch({ channel: 'msedge' });
+const page = await browser.newPage();
+
+let total = 0;
+for (const route of routes) {
+  await page.goto(base + route, { waitUntil: 'networkidle' });
+  await page.addScriptTag({ url: AXE_CDN });
+  const results = await page.evaluate(async () => {
+    // eslint-disable-next-line no-undef
+    return await axe.run(document, {
+      runOnly: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    });
+  });
+  const v = results.violations;
+  total += v.length;
+  if (v.length === 0) {
+    console.log(`✓ ${route} — no violations`);
+  } else {
+    console.log(`✗ ${route} — ${v.length} violation(s):`);
+    for (const item of v) {
+      console.log(`   [${item.impact}] ${item.id}: ${item.help}`);
+      for (const node of item.nodes) {
+        console.log(`      → ${node.target.join(' ')}`);
+      }
+    }
+  }
+}
+
+await browser.close();
+console.log(
+  total === 0
+    ? '\nAll routes pass axe-core.'
+    : `\n${total} total violation(s).`,
+);
+process.exit(total === 0 ? 0 : 1);

--- a/astro-frontend/src/components/Nav.astro
+++ b/astro-frontend/src/components/Nav.astro
@@ -25,6 +25,7 @@ const isActive = (href: string) =>
   >
     <a
       href="/"
+      aria-label="Home"
       class="font-mono text-sm font-bold tracking-tight text-text transition-colors hover:text-accent"
     >
       shawky<span class="text-gradient">.dev</span>

--- a/astro-frontend/src/components/ThemeToggle.tsx
+++ b/astro-frontend/src/components/ThemeToggle.tsx
@@ -41,7 +41,7 @@ export default function ThemeToggle() {
       onClick={toggle}
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       aria-pressed={isDark}
-      className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface text-text shadow-sm transition-colors hover:bg-surface-muted"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface text-text shadow-sm transition-colors hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
     >
       <motion.span
         key={mounted ? theme : 'init'}

--- a/astro-frontend/src/components/prose/LinkButton.astro
+++ b/astro-frontend/src/components/prose/LinkButton.astro
@@ -72,4 +72,8 @@ const external = /^https?:\/\//.test(href);
   .link-button:hover {
     background-color: var(--primary-hover);
   }
+  .link-button:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
 </style>

--- a/astro-frontend/src/layouts/PortfolioLayout.astro
+++ b/astro-frontend/src/layouts/PortfolioLayout.astro
@@ -13,8 +13,9 @@ const { title, description, image, type } = Astro.props;
 ---
 
 <Layout title={title} description={description} image={image} type={type}>
+  <a href="#main" class="skip-link">Skip to content</a>
   <Nav />
-  <main class="mx-auto max-w-5xl px-4 py-12 sm:py-16">
+  <main id="main" tabindex="-1" class="mx-auto max-w-5xl px-4 py-12 sm:py-16">
     <slot />
   </main>
   <footer class="border-t border-border">

--- a/astro-frontend/src/pages/contacts.astro
+++ b/astro-frontend/src/pages/contacts.astro
@@ -19,15 +19,16 @@ const contacts = (await getCollection('contacts')).sort(
     subtitle="Always happy to talk about software, opportunities, or a good idea. Reach me on any of these."
   />
 
-  <ul class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-    {
-      contacts.map((c) => (
-        <FadeIn client:visible>
+  <FadeIn client:visible>
+    <ul class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      {
+        contacts.map((c) => (
           <li>
             <a
               href={c.data.link}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${c.data.name} (opens in a new tab)`}
               class="gradient-border lift flex h-full items-center gap-4 p-5"
             >
               <img
@@ -40,8 +41,8 @@ const contacts = (await getCollection('contacts')).sort(
               <span class="font-medium text-text">{c.data.name}</span>
             </a>
           </li>
-        </FadeIn>
-      ))
-    }
-  </ul>
+        ))
+      }
+    </ul>
+  </FadeIn>
 </PortfolioLayout>

--- a/astro-frontend/src/pages/index.astro
+++ b/astro-frontend/src/pages/index.astro
@@ -72,7 +72,7 @@ const contacts = (await getCollection('contacts')).sort(
     </article>
   </FadeIn>
 
-  <section class="mt-14">
+  <section class="mt-14" aria-label="Social and contact links">
     <h2 class="eyebrow mb-4 text-text-muted">Find me online</h2>
     <ul class="flex flex-wrap gap-3">
       {
@@ -82,6 +82,7 @@ const contacts = (await getCollection('contacts')).sort(
               href={c.data.link}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${c.data.name} (opens in a new tab)`}
               class="lift inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm text-text transition-colors hover:border-accent hover:text-accent"
             >
               <img

--- a/astro-frontend/src/styles/global.css
+++ b/astro-frontend/src/styles/global.css
@@ -93,6 +93,57 @@ body {
 }
 
 /*
+ * Accessibility: a consistent keyboard focus indicator for every interactive
+ * element. Uses :focus-visible so it only shows for keyboard/AT users, not on
+ * mouse clicks. Components may layer richer focus styling on top.
+ */
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: var(--rad-sm);
+}
+
+/* Visually-hidden content that remains available to screen readers. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Skip-to-content link: hidden until focused, then pinned top-left. */
+.skip-link {
+  position: absolute;
+  left: 0.75rem;
+  top: -3rem;
+  z-index: 100;
+  padding: 0.6rem 1rem;
+  border-radius: var(--rad-md);
+  background-color: var(--surface);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-elevation);
+  font-weight: 600;
+  text-decoration: none;
+  transition: top var(--duration-fast) ease-out;
+}
+.skip-link:focus {
+  top: 0.75rem;
+}
+
+/* The skip-link target is a programmatic focus stop, not an interactive
+ * control — don't draw an outline around the whole main region. */
+main:focus,
+main:focus-visible {
+  outline: none;
+}
+
+/*
  * Flow spacing — owl selector for consistent vertical rhythm.
  * Each child gets top margin from --flow-space (defaults to 1em, so it
  * scales with the element's own font size). Override per-context with
@@ -298,6 +349,10 @@ body {
   transform: translateY(-4px);
   box-shadow: var(--elevation-lg);
 }
+.lift:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: var(--elevation-lg);
+}
 
 /* Animated gradient underline that grows in from the left on hover. */
 .underline-grow {
@@ -320,6 +375,9 @@ body {
 .underline-grow:hover::after {
   transform: scaleX(1);
 }
+.underline-grow:focus-visible::after {
+  transform: scaleX(1);
+}
 .underline-grow[aria-current='page']::after {
   transform: scaleX(1);
 }
@@ -338,5 +396,12 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .text-gradient-animated {
     animation: none;
+  }
+  .lift {
+    transition: none;
+  }
+  .lift:hover,
+  .lift:focus-visible {
+    transform: none;
   }
 }

--- a/astro-frontend/src/styles/tokens.css
+++ b/astro-frontend/src/styles/tokens.css
@@ -108,8 +108,8 @@
   --text-color: var(--base-800);
   --text-muted: var(--base-600);
   --text-inverted: var(--base-50);
-  --primary: var(--secondary-500);
-  --primary-hover: var(--secondary-600);
+  --primary: var(--secondary-600);
+  --primary-hover: var(--secondary-700);
   --primary-contrast: var(--base-0);
   --accent: var(--secondary-400);
   --ring: var(--secondary-400);


### PR DESCRIPTION
## Accessibility pass — Epic #38, closes #30

A focused a11y audit + fixes across the Astro app, validated with automated axe-core testing (wcag2a/2aa/21a/21aa) on all 6 routes — **0 violations**.

### Keyboard & focus
- Added a **skip-to-content** link (`Skip to content` → `#main`) and `<main id="main" tabindex="-1">`.
- Global `:focus-visible` baseline outline for interactive elements + `.sr-only` utility.
- Per-component focus states: `ThemeToggle` focus ring, `.link-button` focus-visible outline, `.lift` cards focus-visible, `.underline-grow` reveal on focus.
- Reduced-motion guard for `.lift` hover transforms.

### Labels & semantics
- `aria-label="Home"` on the logo link.
- `aria-label="…(opens in a new tab)"` on external contact links (home + contacts).
- `aria-label` on the "Find me online" social section.
- **Fixed list semantics on `/contacts`**: wrapped the whole `<ul>` in a single `FadeIn` so `<ul>` directly contains `<li>` (previously each item's island broke the `ul→li` relationship).

### Contrast
- Darkened light-theme `--primary` to `--secondary-600` (#93684b ≈ 4.9:1 with white) so the primary button passes WCAG AA (was ≈3.4:1). Dark theme already passed.

### Tooling
- New `scripts/a11y-check.mjs`: axe-core (via CDN) + Playwright/Edge checker that runs all routes and exits non-zero on violations. No new dependency.

### Validation
- `eslint .` — 0 errors
- `astro check` — 0 errors
- `astro build` — success
- `axe-core` — 0 violations on `/`, `/skills`, `/education`, `/experience`, `/projects`, `/contacts`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>