### PR TITLE
docs: rewrite README for the current Vite + React + Sanity stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,129 @@
 # My Portfolio
 
-This project is my portfolio that I created to showcase my skills, interests, and achievements in software development. I wanted to create a portfolio that reflects my personality and passion for coding, as well as my education and experience.
+[![Live Demo](https://img.shields.io/badge/Live-Demo-000000?style=flat&logo=vercel&logoColor=white)](https://shawkyebrahim.vercel.app)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white)](https://vite.dev)
+[![Sanity](https://img.shields.io/badge/Sanity-CMS-F03E2F?logo=sanity&logoColor=white)](https://www.sanity.io)
+
+My personal developer portfolio — a fast, responsive single-page application
+that showcases my skills, experience, education, and projects. Content is
+managed through a Sanity CMS and rendered by a React + TypeScript frontend.
+
+**🔗 Live site: [shawkyebrahim.vercel.app](https://shawkyebrahim.vercel.app)**
+
+<!--
+  📸 Tip: add a screenshot at docs/screenshot.png and uncomment the line below
+  for a hero preview (recommended size ~1280×640).
+-->
+<!-- ![Portfolio preview](docs/screenshot.png) -->
 
 ## Table of Contents
 
-- Features
-- Technologies
-- Installation
-- Usage
-- Contribution
-- License
+- [Tech Stack](#tech-stack)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
+- [Available Scripts](#available-scripts)
+- [Features](#features)
+- [License](#license)
+- [Contact](#contact)
+
+## Tech Stack
+
+**Frontend**
+
+- [React 18](https://react.dev) + [TypeScript](https://www.typescriptlang.org)
+- [Vite](https://vite.dev) — build tool & dev server
+- [React Router](https://reactrouter.com) — client-side routing
+- [Emotion](https://emotion.sh) — CSS-in-JS styling
+- [react-spring](https://www.react-spring.dev) — animations
+- [Font Awesome](https://fontawesome.com) — icons
+- [react-markdown](https://github.com/remarkjs/react-markdown) — Markdown content rendering
+- [Vercel Analytics](https://vercel.com/analytics)
+
+**Content / Backend**
+
+- [Sanity](https://www.sanity.io) — headless CMS (Sanity Studio)
+
+**Tooling**
+
+- [Vitest](https://vitest.dev) + [Testing Library](https://testing-library.com) — testing
+- Deployed on [Vercel](https://vercel.com)
+
+## Project Structure
+
+This is a monorepo with two independent workspaces:
+
+```
+My-Portfolio/
+├── react-frontend/   # React + Vite single-page application
+│   └── src/
+│       ├── APIs/         # Sanity data fetching
+│       ├── components/   # Reusable UI components
+│       ├── containers/   # Page-level layout sections
+│       ├── contexts/     # React context providers
+│       └── Portfolio/    # Page composition
+└── sanity-backend/   # Sanity Studio (content schemas & CMS)
+    └── schemas/          # Portfolio content models
+```
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org) (LTS recommended) and npm
+
+### Frontend (`react-frontend`)
+
+```bash
+cd react-frontend
+npm install
+npm run dev
+```
+
+The app opens automatically at <http://localhost:5173>.
+
+### Content Studio (`sanity-backend`)
+
+```bash
+cd sanity-backend
+npm install
+npm run dev
+```
+
+Sanity Studio runs at <http://localhost:3333>.
+
+## Available Scripts
+
+Run these inside `react-frontend/`:
+
+| Script            | Description                              |
+| ----------------- | ---------------------------------------- |
+| `npm run dev`     | Start the Vite dev server                |
+| `npm run build`   | Build for production (outputs to `build/`) |
+| `npm run preview` | Preview the production build locally     |
+| `npm test`        | Run the test suite with Vitest           |
 
 ## Features
 
-My portfolio consists of the following pages:
+- **Home** — a short introduction about me.
+- **Skills** — languages, frameworks, tools, and concepts I work with.
+- **Education** — degree and relevant coursework.
+- **Experience** — internships and professional training.
+- **Projects** — selected projects I've built.
+- **Contact** — ways to get in touch.
 
-- Home: This is the landing page of my portfolio, where I briefly write about myself.
-
-- Skills: This is the page where I put all the skills that I know and have, such as programming languages, frameworks, tools, and concepts.
-
-- Education: This is the page where I wrote about my education and the relevant courses that I have taken, such as data structures, algorithms, databases, web development, and software engineering.
-
-- Experience: This is the page where I wrote about my internships and training that I have taken.
-
-- Projects: This is the page where I wrote about the important projects that I have built.
-
-- Contact: This is the page where I put all the contacts that anyone can reach me through.
-
-## Technologies
-
-I used the following tools and technologies to build my portfolio:
-
-- ReactJS
-- Framer-motion
-- Fontawesome
-- Sanity
-
-## Installation
-
-To install my portfolio locally, you need to have Node.js and npm installed on your machine. Then, follow these steps:
-
-- Clone the repository: `git clone https://github.com/shawkyebrahim2514/My-Portfolio.git`
-- Go to the project directory: `cd react-frontend` or `cd sanity-backend`
-- Install the dependencies: `npm install`
-- Start the development server: `npm start`
-- Open your browser and go to <http://localhost:3000> in case you run the react-frontend application
-
-## Contribution
-
-I welcome any contribution to my portfolio, such as reporting issues, suggesting features, or making pull requests. Please follow these guidelines:
-
-- Create an issue to describe the problem or the feature that you want to work on.
-- Fork the repository and create a new branch with a descriptive name, such as `feature/new-feature` or `fix/issue-number`.
-- Make your changes and commit them with a clear and concise message, such as `Add new feature` or `Fix issue number`.
-- Push your changes to your forked repository and create a pull request to the main branch of the original repository.
-- Wait for the review and approval of your pull request.
+All content is editable through the Sanity Studio without touching code.
 
 ## License
 
-My portfolio is licensed under the MIT License. See the LICENSE file for more details.
+This project is licensed under the MIT License — see the [LICENSE](./LICENSE)
+file for details.
 
 ## Contact
 
-Thank you for visiting my portfolio. If you have any questions or feedback, please feel free to contact me via email or LinkedIn.
+Thanks for visiting! Questions or feedback are always welcome.
 
-- Email: <shawkyebrahim2514@gmail.com>
-- LinkedIn: <https://www.linkedin.com/in/shawkyebrahim2514/>
+- **Email:** <shawkyebrahim2514@gmail.com>
+- **LinkedIn:** [shawkyebrahim2514](https://www.linkedin.com/in/shawkyebrahim2514/)


### PR DESCRIPTION
## Summary

Rewrites the root `README.md` to accurately reflect the current stack and follow best practices for a portfolio repo. Part of the repo presentation refresh (description + topics were also updated via API).

## What changed

- **Accurate tech stack** — fixes the old list (was "framer-motion"; actually **react-spring**) and adds **Vite, TypeScript, React Router, Emotion, Vitest, Vercel Analytics**.
- **Correct setup** — old README said `npm start` + `localhost:3000`; now `npm run dev` + `localhost:5173` (post-Vite), with separate steps for `react-frontend` and `sanity-backend`.
- **Badges** — live demo, MIT license, React/TypeScript/Vite/Sanity.
- **Prominent live-demo link** at the top.
- **Monorepo structure** diagram (`react-frontend/` vs `sanity-backend/`).
- **Scripts table** and linked table of contents.
- Screenshot placeholder (commented out) with guidance to drop one at `docs/screenshot.png`.

## Notes

- No application code touched.
- The only remaining presentation item that can't be automated is uploading a **social-preview image** (Settings → General → Social preview).