### PR TITLE
docs: bring README, LICENSE, security policy, and dependabot config to main

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+This is a personal portfolio project. Only the latest version deployed from the
+`main` branch is actively maintained and receives security updates.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| `main` (latest)| :white_check_mark: |
+| older          | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not open a public issue**.
+
+Instead, report it privately through one of the following channels:
+
+- Use GitHub's [private vulnerability reporting](https://github.com/shawkyebrahim2514/My-Portfolio/security/advisories/new)
+  (preferred).
+- Or reach out directly via the contact details listed on the portfolio site.
+
+Please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof of concept.
+- Any suggested remediation, if known.
+
+You can expect an initial acknowledgement within **7 days**. Once the issue is
+confirmed, a fix will be prioritized and you will be kept informed of progress.
+
+Thank you for helping keep this project and its users safe.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot configuration
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Frontend (React + Vite) dependencies
+  - package-ecosystem: "npm"
+    directory: "/react-frontend"
+    target-branch: "Development"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "react-frontend"
+    groups:
+      react-frontend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Sanity backend dependencies
+  - package-ecosystem: "npm"
+    directory: "/sanity-backend"
+    target-branch: "Development"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "sanity-backend"
+    groups:
+      sanity-backend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "Development"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shawky Ebrahim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,68 +1,129 @@
 # My Portfolio
 
-This project is my portfolio that I created to showcase my skills, interests, and achievements in software development. I wanted to create a portfolio that reflects my personality and passion for coding, as well as my education and experience.
+[![Live Demo](https://img.shields.io/badge/Live-Demo-000000?style=flat&logo=vercel&logoColor=white)](https://shawkyebrahim.vercel.app)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white)](https://vite.dev)
+[![Sanity](https://img.shields.io/badge/Sanity-CMS-F03E2F?logo=sanity&logoColor=white)](https://www.sanity.io)
+
+My personal developer portfolio — a fast, responsive single-page application
+that showcases my skills, experience, education, and projects. Content is
+managed through a Sanity CMS and rendered by a React + TypeScript frontend.
+
+**🔗 Live site: [shawkyebrahim.vercel.app](https://shawkyebrahim.vercel.app)**
+
+<!--
+  📸 Tip: add a screenshot at docs/screenshot.png and uncomment the line below
+  for a hero preview (recommended size ~1280×640).
+-->
+<!-- ![Portfolio preview](docs/screenshot.png) -->
 
 ## Table of Contents
 
-- Features
-- Technologies
-- Installation
-- Usage
-- Contribution
-- License
+- [Tech Stack](#tech-stack)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
+- [Available Scripts](#available-scripts)
+- [Features](#features)
+- [License](#license)
+- [Contact](#contact)
+
+## Tech Stack
+
+**Frontend**
+
+- [React 18](https://react.dev) + [TypeScript](https://www.typescriptlang.org)
+- [Vite](https://vite.dev) — build tool & dev server
+- [React Router](https://reactrouter.com) — client-side routing
+- [Emotion](https://emotion.sh) — CSS-in-JS styling
+- [react-spring](https://www.react-spring.dev) — animations
+- [Font Awesome](https://fontawesome.com) — icons
+- [react-markdown](https://github.com/remarkjs/react-markdown) — Markdown content rendering
+- [Vercel Analytics](https://vercel.com/analytics)
+
+**Content / Backend**
+
+- [Sanity](https://www.sanity.io) — headless CMS (Sanity Studio)
+
+**Tooling**
+
+- [Vitest](https://vitest.dev) + [Testing Library](https://testing-library.com) — testing
+- Deployed on [Vercel](https://vercel.com)
+
+## Project Structure
+
+This is a monorepo with two independent workspaces:
+
+```
+My-Portfolio/
+├── react-frontend/   # React + Vite single-page application
+│   └── src/
+│       ├── APIs/         # Sanity data fetching
+│       ├── components/   # Reusable UI components
+│       ├── containers/   # Page-level layout sections
+│       ├── contexts/     # React context providers
+│       └── Portfolio/    # Page composition
+└── sanity-backend/   # Sanity Studio (content schemas & CMS)
+    └── schemas/          # Portfolio content models
+```
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org) (LTS recommended) and npm
+
+### Frontend (`react-frontend`)
+
+```bash
+cd react-frontend
+npm install
+npm run dev
+```
+
+The app opens automatically at <http://localhost:5173>.
+
+### Content Studio (`sanity-backend`)
+
+```bash
+cd sanity-backend
+npm install
+npm run dev
+```
+
+Sanity Studio runs at <http://localhost:3333>.
+
+## Available Scripts
+
+Run these inside `react-frontend/`:
+
+| Script            | Description                              |
+| ----------------- | ---------------------------------------- |
+| `npm run dev`     | Start the Vite dev server                |
+| `npm run build`   | Build for production (outputs to `build/`) |
+| `npm run preview` | Preview the production build locally     |
+| `npm test`        | Run the test suite with Vitest           |
 
 ## Features
 
-My portfolio consists of the following pages:
+- **Home** — a short introduction about me.
+- **Skills** — languages, frameworks, tools, and concepts I work with.
+- **Education** — degree and relevant coursework.
+- **Experience** — internships and professional training.
+- **Projects** — selected projects I've built.
+- **Contact** — ways to get in touch.
 
-- Home: This is the landing page of my portfolio, where I briefly write about myself.
-
-- Skills: This is the page where I put all the skills that I know and have, such as programming languages, frameworks, tools, and concepts.
-
-- Education: This is the page where I wrote about my education and the relevant courses that I have taken, such as data structures, algorithms, databases, web development, and software engineering.
-
-- Experience: This is the page where I wrote about my internships and training that I have taken.
-
-- Projects: This is the page where I wrote about the important projects that I have built.
-
-- Contact: This is the page where I put all the contacts that anyone can reach me through.
-
-## Technologies
-
-I used the following tools and technologies to build my portfolio:
-
-- ReactJS
-- Framer-motion
-- Fontawesome
-- Sanity
-
-## Installation
-
-To install my portfolio locally, you need to have Node.js and npm installed on your machine. Then, follow these steps:
-
-- Clone the repository: `git clone https://github.com/shawkyebrahim2514/My-Portfolio.git`
-- Go to the project directory: `cd react-frontend` or `cd sanity-backend`
-- Install the dependencies: `npm install`
-- Start the development server: `npm start`
-- Open your browser and go to <http://localhost:3000> in case you run the react-frontend application
-
-## Contribution
-
-I welcome any contribution to my portfolio, such as reporting issues, suggesting features, or making pull requests. Please follow these guidelines:
-
-- Create an issue to describe the problem or the feature that you want to work on.
-- Fork the repository and create a new branch with a descriptive name, such as `feature/new-feature` or `fix/issue-number`.
-- Make your changes and commit them with a clear and concise message, such as `Add new feature` or `Fix issue number`.
-- Push your changes to your forked repository and create a pull request to the main branch of the original repository.
-- Wait for the review and approval of your pull request.
+All content is editable through the Sanity Studio without touching code.
 
 ## License
 
-My portfolio is licensed under the MIT License. See the LICENSE file for more details.
+This project is licensed under the MIT License — see the [LICENSE](./LICENSE)
+file for details.
 
 ## Contact
 
-Thank you for visiting my portfolio. If you have any questions or feedback, please feel free to contact me via email or LinkedIn.
+Thanks for visiting! Questions or feedback are always welcome.
 
-- Email: <shawkyebrahim2514@gmail.com>
-- LinkedIn: <https://www.linkedin.com/in/shawkyebrahim2514/>
+- **Email:** <shawkyebrahim2514@gmail.com>
+- **LinkedIn:** [shawkyebrahim2514](https://www.linkedin.com/in/shawkyebrahim2514/)


### PR DESCRIPTION
Syncs the documentation and governance files from `Development` onto the default branch (`main`) so they take effect on the repo homepage.

## Why a targeted file sync (not a full Development merge)

A full `Development` -> `main` merge would have **reverted** the Dependabot dependency bumps (#46, #47) that were merged directly into `main`, because `Development` still carries the older `sanity-backend` lockfile. This PR brings only the four docs/governance files, leaving `main`'s dependency state intact.

## Files

- `README.md` - rewritten for the current Vite + React + Sanity stack
- `LICENSE` - MIT
- `.github/SECURITY.md` - security policy
- `.github/dependabot.yml` - so Dependabot reads its config from `main` and targets `Development` going forward

No application code is touched.