### PR TITLE
fix(deps): resolve FontAwesome 7 peer conflict breaking Vercel build

### DIFF
--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
-        "@fortawesome/react-fontawesome": "^0.2.2",
+        "@fortawesome/react-fontawesome": "^3.3.1",
         "@react-spring/web": "^10.1.2",
         "@sanity/client": "^7.23.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1146,15 +1146,16 @@
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
-      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
+        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.14.0",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",
-    "@fortawesome/react-fontawesome": "^0.2.2",
+    "@fortawesome/react-fontawesome": "^3.3.1",
     "@react-spring/web": "^10.1.2",
     "@sanity/client": "^7.23.0",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
Promotes the FontAwesome react-fontawesome 3.3.1 fix (#75) to main to unbreak production Vercel builds. Validated via npm ci + build on Development.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>