### PR TITLE
refactor: centralize styling into CSS Modules + design tokens (Phase 0)

### DIFF
--- a/react-frontend/.env.example
+++ b/react-frontend/.env.example
@@ -1,0 +1,5 @@
+# Sanity content source (public project values; safe to expose in the client).
+# Copy to .env.local to override. All VITE_* vars are bundled into the client.
+VITE_SANITY_PROJECT_ID=h48br789
+VITE_SANITY_DATASET=production
+VITE_SANITY_API_VERSION=2022-03-07

--- a/react-frontend/.prettierignore
+++ b/react-frontend/.prettierignore
@@ -1,0 +1,6 @@
+build
+dist
+node_modules
+coverage
+package-lock.json
+*.svg

--- a/react-frontend/.prettierrc.json
+++ b/react-frontend/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "printWidth": 100
+}

--- a/react-frontend/eslint.config.mjs
+++ b/react-frontend/eslint.config.mjs
@@ -1,0 +1,38 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+    {
+        ignores: ['build', 'dist', 'node_modules', 'coverage'],
+    },
+    {
+        files: ['**/*.{ts,tsx}'],
+        extends: [
+            js.configs.recommended,
+            ...tseslint.configs.recommended,
+            reactHooks.configs['recommended-latest'],
+        ],
+        languageOptions: {
+            ecmaVersion: 2020,
+            globals: globals.browser,
+        },
+        plugins: {
+            'react-refresh': reactRefresh,
+        },
+        rules: {
+            'react-refresh/only-export-components': [
+                'warn',
+                { allowConstantExport: true },
+            ],
+            '@typescript-eslint/no-unused-vars': [
+                'warn',
+                { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+            ],
+        },
+    },
+    prettier
+);

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -36,9 +36,17 @@
         "web-vitals": "^4.2.4"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@vitejs/plugin-react": "^6.0.3",
+        "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.26",
+        "globals": "^17.7.0",
         "jsdom": "^29.1.1",
+        "prettier": "^3.9.4",
         "typescript": "5.6.3",
+        "typescript-eslint": "^8.62.1",
         "vite": "^8.1.0",
         "vitest": "^4.1.9"
       }
@@ -540,6 +548,163 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -602,6 +767,72 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~6 || ~7",
         "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jest/expect-utils": {
@@ -1336,6 +1567,13 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1410,6 +1648,288 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.2",
@@ -1601,6 +2121,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1625,6 +2185,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -1670,6 +2237,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1678,6 +2252,17 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1820,6 +2405,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -1862,6 +2454,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-mediaquery": {
@@ -1962,6 +2569,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2060,6 +2674,189 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -2078,6 +2875,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/event-source-polyfill": {
@@ -2127,6 +2934,40 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2144,6 +2985,44 @@
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2182,6 +3061,32 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -2322,6 +3227,16 @@
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2336,6 +3251,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -2414,6 +3339,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -2463,6 +3411,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
@@ -2642,6 +3597,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "29.1.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
@@ -2695,11 +3673,56 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2978,6 +4001,29 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -3951,6 +4997,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3975,6 +5034,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3996,6 +5062,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parent-module": {
@@ -4066,6 +5182,26 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4133,6 +5269,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -4556,6 +5718,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -4567,6 +5742,29 @@
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
       "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4681,6 +5879,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/style-to-js": {
@@ -4900,6 +6111,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4918,6 +6142,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -4930,6 +6167,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {
@@ -5033,6 +6294,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5330,6 +6601,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5345,6 +6632,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/xml-name-validator": {
@@ -5364,20 +6661,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 14.6"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/eemeli"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zwitch": {

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -34,7 +34,10 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "lint": "eslint .",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\""
   },
   "browserslist": {
     "production": [
@@ -49,9 +52,17 @@
     ]
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@vitejs/plugin-react": "^6.0.3",
+    "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^17.7.0",
     "jsdom": "^29.1.1",
+    "prettier": "^3.9.4",
     "typescript": "5.6.3",
+    "typescript-eslint": "^8.62.1",
     "vite": "^8.1.0",
     "vitest": "^4.1.9"
   },

--- a/react-frontend/src/APIs/Sanity/client.ts
+++ b/react-frontend/src/APIs/Sanity/client.ts
@@ -1,10 +1,12 @@
 import { createClient } from '@sanity/client'
 
+// Config is sourced from Vite env vars, falling back to the public project
+// defaults so the app keeps working without a local .env. See .env.example.
 const sanityClient = createClient({
-    projectId: 'h48br789',
-    dataset: 'production',
+    projectId: import.meta.env.VITE_SANITY_PROJECT_ID ?? 'h48br789',
+    dataset: import.meta.env.VITE_SANITY_DATASET ?? 'production',
+    apiVersion: import.meta.env.VITE_SANITY_API_VERSION ?? '2022-03-07',
     useCdn: true,
-    apiVersion: '2022-03-07',
 })
 
 export default sanityClient;

--- a/react-frontend/src/Portfolio/Portfolio.module.css
+++ b/react-frontend/src/Portfolio/Portfolio.module.css
@@ -1,0 +1,20 @@
+.page {
+    background-color: var(--color-base-100);
+    min-height: 100vh;
+    color: var(--color-base-700);
+    background-image: var(--portfolio-bg);
+    background-size: auto;
+    background-repeat: repeat;
+    background-position: center;
+}
+
+.page *::selection {
+    background-color: var(--color-base-700);
+    color: var(--color-base-100);
+}
+
+.inner {
+    max-width: 1255px;
+    margin: 0 auto;
+    padding: 0 1rem;
+}

--- a/react-frontend/src/Portfolio/index.tsx
+++ b/react-frontend/src/Portfolio/index.tsx
@@ -1,9 +1,6 @@
-/** @jsxImportSource @emotion/react */
-
-import { useThemeContext } from '../contexts/ThemeContext';
 import Navbar from '../components/Navbar';
 import Contacts from '../containers/Contacts';
-import { Suspense, lazy } from 'react';
+import { CSSProperties, Suspense, lazy } from 'react';
 import Loader from '../components/Loader';
 import {
     BrowserRouter,
@@ -11,57 +8,37 @@ import {
     Routes,
 } from "react-router-dom";
 import { PortfolioPathes } from '../Types';
-import { css } from '@emotion/react';
-import MarkdownEditor from '../containers/MarkdownEditor';
+import backgroundImage from '../assets/background.svg';
+import styles from './Portfolio.module.css';
 
 const About = lazy(() => import('../containers/About'));
 const Skills = lazy(() => import('../containers/Skills'));
 const Education = lazy(() => import('../containers/Education'));
 const Experience = lazy(() => import('../containers/Experience'));
 const Projects = lazy(() => import('../containers/Projects'));
+const MarkdownEditor = lazy(() => import('../containers/MarkdownEditor'));
 
 type PathElementRoutes = Record<PortfolioPathes, React.JSX.Element>
-type TestingRoutes = {
-    "markdown": React.JSX.Element
-}
 
-const pathElementRoutes: PathElementRoutes & TestingRoutes = {
+const pathElementRoutes: PathElementRoutes = {
     "": <About />,
     "skills": <Skills />,
     "education": <Education />,
     "experience": <Experience />,
     "projects": <Projects />,
     "contacts": <Contacts />,
-    "markdown": <MarkdownEditor />
 }
 
 export default function Portfolio() {
-    const { theme } = useThemeContext();
-
     return (
-        <div css={css({
-            backgroundColor: theme.colors.base[100],
-            minHeight: "100vh",
-            color: theme.colors.base[700],
-            backgroundImage: theme.backgroundImage,
-            backgroundSize: 'auto', // Adjust the size of the background image
-            backgroundRepeat: 'repeat', // Repeat the background image
-            backgroundPosition: 'center',
-            '& *::selection': {
-                backgroundColor: theme.colors.base[700],
-                color: theme.colors.base[100]
-            }
-        })}>
-            <div style={{
-                maxWidth: "1255px",
-                margin: "0 auto",
-                padding: "0 1rem",
-            }}>
+        <div
+            className={styles.page}
+            style={{ '--portfolio-bg': `url(${backgroundImage})` } as CSSProperties}>
+            <div className={styles.inner}>
                 <Suspense fallback={<Loader />}>
                     <BrowserRouter>
                         <Navbar />
                         <Routes>
-                            <Route path='/' element={<About />} />
                             {Object.entries(pathElementRoutes).map(([path, element]) => {
                                 return (
                                     <Route
@@ -70,6 +47,10 @@ export default function Portfolio() {
                                         element={element} />
                                 )
                             })}
+                            {/* Markdown editor is a dev-only authoring tool, not shipped in production routing. */}
+                            {import.meta.env.DEV && (
+                                <Route path="/markdown" element={<MarkdownEditor />} />
+                            )}
                         </Routes>
                     </BrowserRouter>
                 </Suspense>

--- a/react-frontend/src/Types/contexts.ts
+++ b/react-frontend/src/Types/contexts.ts
@@ -1,3 +1,6 @@
+import { CSSObject } from '@emotion/react';
+import { CSSProperties } from 'react';
+
 type ColorLevels = {
     0: string,
     50: string,
@@ -16,19 +19,19 @@ type Theme = {
     colors: {
         base: ColorLevels,
         secondary: ColorLevels,
-        opacity: (percentage: number) => void
+        opacity: (percentage: number) => string
     },
     transition: string,
     borderRadius: string,
     boxShadow: string,
     backgroundImage: string,
     border: string,
-    button: object,
-    boxingStyle: object,
-    container: object,
-    buttonEffects: object,
+    button: CSSObject,
+    boxingStyle: CSSProperties,
+    container: CSSProperties,
+    buttonEffects: CSSObject,
 };
 
 type PortfolioPathes = "" | "skills" | "education" | "experience" | "projects" | "contacts";
 
-export { type Theme, type PortfolioPathes }
+export { type Theme, type PortfolioPathes, type ColorLevels }

--- a/react-frontend/src/Types/index.ts
+++ b/react-frontend/src/Types/index.ts
@@ -9,4 +9,4 @@ export {
     type SanityNavbarData
 } from './sanity';
 
-export { type Theme, type PortfolioPathes } from './contexts';
+export { type Theme, type PortfolioPathes, type ColorLevels } from './contexts';

--- a/react-frontend/src/components/BlurBackground.module.css
+++ b/react-frontend/src/components/BlurBackground.module.css
@@ -1,0 +1,9 @@
+.blur {
+    z-index: -1;
+    position: absolute;
+    backdrop-filter: blur(8px);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/react-frontend/src/components/BlurBackground.tsx
+++ b/react-frontend/src/components/BlurBackground.tsx
@@ -1,4 +1,4 @@
-/** @jsxImportSource @emotion/react */
+import styles from './BlurBackground.module.css';
 
 type BlurBackgroundProps = {
     backgroundColor: string,
@@ -6,19 +6,8 @@ type BlurBackgroundProps = {
 
 export default function BlurBackground({ backgroundColor }: BlurBackgroundProps) {
     return (
-        <div css={{
-            zIndex: -1,
-            position: "absolute",
-            backgroundColor: toRGBA(backgroundColor, 0.8),
-            backdropFilter: "blur(8px)",
-            top: "0",
-            left: "0",
-            width: "100%",
-            height: "100%",
-        }} />
+        <div
+            className={styles.blur}
+            style={{ backgroundColor: `color-mix(in srgb, ${backgroundColor} 80%, transparent)` }} />
     )
-}
-
-function toRGBA(color: string, alpha: number) {
-    return `${color}${Math.round(alpha * 255).toString(16)}`;
 }

--- a/react-frontend/src/components/Button/Button.module.css
+++ b/react-frontend/src/components/Button/Button.module.css
@@ -1,0 +1,43 @@
+.button {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: center;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    background-color: var(--color-base-50);
+    color: var(--color-base-700);
+    transition: var(--transition);
+    cursor: default;
+    font-family: inherit;
+}
+
+.button:hover {
+    transform: scale(1.05);
+}
+
+.button:active {
+    transform: scale(0.95);
+    color: var(--color-base-200);
+    background-color: var(--color-base-600);
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+.sm {
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+}
+
+.md {
+    font-size: 1rem;
+    padding: 0.35rem 0.6rem;
+}
+
+.lg {
+    font-size: 1rem;
+    padding: 0.5rem 1rem;
+}

--- a/react-frontend/src/components/Button/Button.module.css
+++ b/react-frontend/src/components/Button/Button.module.css
@@ -27,6 +27,12 @@
     cursor: pointer;
 }
 
+.ghost {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}
+
 .sm {
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;

--- a/react-frontend/src/components/Button/index.tsx
+++ b/react-frontend/src/components/Button/index.tsx
@@ -6,7 +6,9 @@ type ButtonProps = {
     readonly text?: string;
     readonly onClick?: () => void;
     readonly size?: 'sm' | 'md' | 'lg';
+    readonly variant?: 'solid' | 'ghost';
     readonly style?: React.CSSProperties;
+    readonly className?: string;
     readonly pointer?: boolean;
     readonly children?: React.ReactNode;
 };
@@ -16,14 +18,22 @@ export default function Button({
     text,
     onClick,
     size = 'lg',
+    variant = 'solid',
     style,
+    className,
     pointer,
     children,
 }: ButtonProps) {
     return (
         <button
             type="button"
-            className={cx(styles.button, styles[size], pointer && styles.pointer)}
+            className={cx(
+                styles.button,
+                styles[size],
+                variant === 'ghost' && styles.ghost,
+                pointer && styles.pointer,
+                className
+            )}
             style={style}
             onClick={onClick}
         >

--- a/react-frontend/src/components/Button/index.tsx
+++ b/react-frontend/src/components/Button/index.tsx
@@ -1,58 +1,35 @@
-/** @jsxImportSource @emotion/react */
-
-import { useCallback, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
-import { css } from '@emotion/react';
-
-const differentSizes = {
-    sm: {
-        fontSize: "0.8rem",
-        padding: "0.25rem 0.5rem",
-    },
-    md: {
-        fontSize: "1rem",
-        padding: "0.35rem 0.6rem",
-    },
-    lg: {
-        fontSize: "1rem",
-        padding: "0.5rem 1rem",
-    }
-}
+import { cx } from '../../utils/cx';
+import styles from './Button.module.css';
 
 type ButtonProps = {
     readonly icon?: React.JSX.Element;
     readonly text?: string;
     readonly onClick?: () => void;
-    readonly size?: keyof typeof differentSizes;
+    readonly size?: 'sm' | 'md' | 'lg';
     readonly style?: React.CSSProperties;
     readonly pointer?: boolean;
-    readonly children?: React.JSX.Element[];
-}
+    readonly children?: React.ReactNode;
+};
 
-export default function Button({ icon, text, onClick, size = "lg", style, pointer, children }: ButtonProps) {
-    const { theme } = useThemeContext();
-    const buttonStyle = useMemo(() => css({
-        display: "inline-block",
-        padding: differentSizes[size].padding,
-        fontSize: differentSizes[size].fontSize,
-        cursor: pointer ? "pointer" : "default",
-        ...theme.button,
-        ...style,
-    }), [theme, size, style, pointer]);
-    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === "Enter") {
-            onClick?.();
-        }
-    }, [onClick]);
-
+export default function Button({
+    icon,
+    text,
+    onClick,
+    size = 'lg',
+    style,
+    pointer,
+    children,
+}: ButtonProps) {
     return (
-        <span
-            css={buttonStyle}
+        <button
+            type="button"
+            className={cx(styles.button, styles[size], pointer && styles.pointer)}
+            style={style}
             onClick={onClick}
-            onKeyDown={handleKeyDown} >
+        >
             {icon}
             {text}
             {children}
-        </span >
-    )
+        </button>
+    );
 }

--- a/react-frontend/src/components/CenteredSection/Header.module.css
+++ b/react-frontend/src/components/CenteredSection/Header.module.css
@@ -1,0 +1,22 @@
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--color-base-700);
+}
+
+.line {
+    width: 100%;
+    height: 1px;
+    background-color: var(--color-base-200);
+    border: none;
+}

--- a/react-frontend/src/components/CenteredSection/Header.tsx
+++ b/react-frontend/src/components/CenteredSection/Header.tsx
@@ -1,6 +1,5 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Text from '../Text'
+import styles from './Header.module.css';
 
 type HeaderProps = {
     readonly title: string,
@@ -9,18 +8,8 @@ type HeaderProps = {
 }
 
 export default function Header({ title, subtitle, icon }: HeaderProps) {
-    const headerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-        }
-    }, []);
-
     return (
-        <header style={headerStyle}>
+        <header className={styles.header}>
             <HeaderTitle title={title} icon={icon} />
             {subtitle && <Text variant={"h3"}>{subtitle}</Text>}
             <HorizontalLine />
@@ -29,19 +18,8 @@ export default function Header({ title, subtitle, icon }: HeaderProps) {
 }
 
 function HeaderTitle({ title, icon }: Readonly<Pick<HeaderProps, "title" | "icon">>) {
-    const { theme } = useThemeContext();
-    const titleStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-            color: theme.colors.base[700],
-        }
-    }, [theme.colors]);
-
     return (
-        <div style={titleStyle}>
+        <div className={styles.title}>
             {icon}
             <Text variant={"h3"}>
                 {title}
@@ -51,17 +29,7 @@ function HeaderTitle({ title, icon }: Readonly<Pick<HeaderProps, "title" | "icon
 }
 
 function HorizontalLine() {
-    const { theme } = useThemeContext();
-    const hrStyle = useMemo((): CSSProperties => {
-        return {
-            width: "100%",
-            height: "1px",
-            backgroundColor: theme.colors.base[200],
-            border: "none",
-        }
-    }, [theme.colors]);
-
     return (
-        <hr style={hrStyle} />
+        <hr className={styles.line} />
     )
 }

--- a/react-frontend/src/components/CenteredSection/index.tsx
+++ b/react-frontend/src/components/CenteredSection/index.tsx
@@ -1,6 +1,6 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Header from './Header';
+import { cx } from '../../utils/cx';
+import surfaces from '../../styles/surfaces.module.css';
 
 type CenteredSectionProps = {
     readonly title: string,
@@ -10,17 +10,8 @@ type CenteredSectionProps = {
 }
 
 export default function CenteredSection({ title, subtitle, icon, children }: CenteredSectionProps) {
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            ...theme.container,
-            flexDirection: "column",
-            textAlign: "center",
-        }
-    }, [theme]);
-
     return (
-        <div style={containerStyle}>
+        <div className={cx(surfaces.container, surfaces.column, surfaces.center)}>
             <Header title={title} subtitle={subtitle} icon={icon} />
             {children}
         </div>

--- a/react-frontend/src/components/ContainerWrap.module.css
+++ b/react-frontend/src/components/ContainerWrap.module.css
@@ -1,0 +1,6 @@
+.container {
+    display: grid;
+    align-items: center;
+    padding-top: 70px;
+    padding-bottom: 30px;
+}

--- a/react-frontend/src/components/ContainerWrap.tsx
+++ b/react-frontend/src/components/ContainerWrap.tsx
@@ -1,16 +1,8 @@
-import { CSSProperties, FC, useMemo } from "react";
+import { FC } from "react";
 import { useTransition, animated } from "@react-spring/web";
+import styles from "./ContainerWrap.module.css";
 
 const ContainerWrap = (Component: FC) => function HOC() {
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "grid",
-            alignItems: "center",
-            paddingTop: "70px",
-            paddingBottom: "30px",
-        }
-    }, []);
-
     const transitions = useTransition(Component, {
         from: { opacity: 0, transform: "translate(-500px)" },
         enter: { opacity: 1, transform: "translate(0)" },
@@ -18,9 +10,9 @@ const ContainerWrap = (Component: FC) => function HOC() {
         config: { duration: 400 },
     });
 
-    return transitions((styles, item) => (item != null) && (
-        <animated.div style={styles}>
-            <div style={containerStyle}>
+    return transitions((style, item) => (item != null) && (
+        <animated.div style={style}>
+            <div className={styles.container}>
                 <Component />
             </div>
         </animated.div>

--- a/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.module.css
@@ -1,0 +1,4 @@
+.button {
+    margin-top: 1rem;
+    margin-right: 1rem;
+}

--- a/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.tsx
@@ -1,8 +1,10 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import Button from '../Button';
 import Header from '../MainSection/Header';
 import type { Element } from 'hast'
 import { faLink, faFileAlt } from '@fortawesome/free-solid-svg-icons';
+import styles from './AncherLinkMarkdown.module.css';
 
 type AncherLinkMarkdownProps = {
     node?: Element,
@@ -10,7 +12,7 @@ type AncherLinkMarkdownProps = {
 
 const iconType = ['doc', 'link'] as const;
 
-const iconName: Record<typeof iconType[number], any> = {
+const iconName: Record<typeof iconType[number], IconDefinition> = {
     doc: faFileAlt,
     link: faLink,
 }
@@ -31,10 +33,7 @@ const AncherLinkMarkdown = ({ node, ...props }: AncherLinkMarkdownProps) => {
                 size='md'
                 onClick={() => { window.open(link, "_blank") }}
                 pointer={true}
-                style={{
-                    marginTop: '1rem',
-                    marginRight: '1rem',
-                }}
+                className={styles.button}
             />
         )
     }

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.module.css
@@ -1,0 +1,30 @@
+.blockquote {
+    padding: 0 1rem;
+    position: relative;
+    margin: 1rem 0;
+}
+
+.bar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 5px;
+    background-color: currentColor;
+}
+
+.baseBar {
+    color: var(--color-base-700);
+}
+
+.secondaryBar {
+    color: var(--color-secondary-500);
+}
+
+.highlightBase {
+    background-color: var(--color-base-200);
+}
+
+.highlightSecondary {
+    background-color: var(--color-secondary-200);
+}

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -21,7 +21,7 @@ type BlockquoteMarkdownProps = {
 const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownProps) => {
     const { theme } = useThemeContext();
     const contentJSXElementsFromAST = useMemo(() => {
-        let content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
+        const content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
             Fragment, jsx, jsxs, passNode: true, components: {
                 ...markdownComponents,
                 br: () => null,
@@ -56,9 +56,9 @@ const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownPro
     }), [theme.colors.base, theme.colors.secondary]);
 
     // By default it will be without-background and base color
-    let backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);
-    let colorType = useMemo((): BlockquoteColorType => className?.includes("secondary") ? "secondary" : "base", [className]);
-    let colors = useMemo(() => targetElement[backgroundType][colorType], [backgroundType, colorType, targetElement]);
+    const backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);
+    const colorType = useMemo((): BlockquoteColorType => className?.includes("secondary") ? "secondary" : "base", [className]);
+    const colors = useMemo(() => targetElement[backgroundType][colorType], [backgroundType, colorType, targetElement]);
 
     if (className?.includes("popup")) {
         return (

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -1,25 +1,21 @@
 import { useMemo } from 'react';
-import { useThemeContext } from '../../contexts/ThemeContext';
 import type { Element, RootContent } from 'hast'
 import MainSection from '../MainSection';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { markdownComponents } from '.';
 import { v4 as uuid } from 'uuid';
+import { cx } from '../../utils/cx';
+import styles from './BlockquoteMarkdown.module.css';
 
 type BlockquoteElementType = "highlight-background" | "without-background";
 type BlockquoteColorType = "base" | "secondary";
-type TargetElementType = Record<BlockquoteElementType, Record<BlockquoteColorType, {
-    containerBackgroundColor: string,
-    barColor: string,
-}>>
 type BlockquoteMarkdownProps = {
     node?: Element,
 } & React.HTMLAttributes<HTMLQuoteElement>;
 
 
 const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownProps) => {
-    const { theme } = useThemeContext();
     const contentJSXElementsFromAST = useMemo(() => {
         const content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
             Fragment, jsx, jsxs, passNode: true, components: {
@@ -32,33 +28,9 @@ const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownPro
         ));
     }, [node?.children]);
 
-    const targetElement = useMemo((): TargetElementType => ({
-        "highlight-background": {
-            "base": {
-                containerBackgroundColor: theme.colors.base[200],
-                barColor: theme.colors.base[700],
-            },
-            "secondary": {
-                containerBackgroundColor: theme.colors.secondary[200],
-                barColor: theme.colors.secondary[500],
-            },
-        },
-        "without-background": {
-            "base": {
-                containerBackgroundColor: "transparent",
-                barColor: theme.colors.base[700],
-            },
-            "secondary": {
-                containerBackgroundColor: "transparent",
-                barColor: theme.colors.secondary[500],
-            },
-        },
-    }), [theme.colors.base, theme.colors.secondary]);
-
     // By default it will be without-background and base color
     const backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);
     const colorType = useMemo((): BlockquoteColorType => className?.includes("secondary") ? "secondary" : "base", [className]);
-    const colors = useMemo(() => targetElement[backgroundType][colorType], [backgroundType, colorType, targetElement]);
 
     if (className?.includes("popup")) {
         return (
@@ -71,22 +43,12 @@ const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownPro
     return (
         <div
             {...props as React.HTMLAttributes<HTMLDivElement>}
-            style={{
-                ...props.style,
-                padding: "0 1rem",
-                position: "relative",
-                margin: "1rem 0",
-                backgroundColor: `${colors.containerBackgroundColor}`,
-                color: `${colors.barColor}`
-            }}>
-            <div style={{
-                position: "absolute",
-                left: 0,
-                height: "100%",
-                top: 0,
-                backgroundColor: `${colors.barColor}`,
-                width: "5px",
-            }} />
+            className={cx(
+                styles.blockquote,
+                colorType === "secondary" ? styles.secondaryBar : styles.baseBar,
+                backgroundType === "highlight-background" && (colorType === "secondary" ? styles.highlightSecondary : styles.highlightBase)
+            )}>
+            <div className={styles.bar} />
             {contentJSXElementsFromAST}
         </div>
     );

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -1,0 +1,52 @@
+.hr {
+    margin: 1rem 0;
+    background-color: var(--color-base-200);
+    height: 1px;
+}
+
+.ul {
+    list-style-type: none;
+}
+
+.li {
+    list-style-type: none;
+    position: relative;
+}
+
+.li::before {
+    content: ">";
+    position: absolute;
+    top: 0;
+    left: -15px;
+    font-weight: 600;
+}
+
+.h1 {
+    font-size: 3.8rem;
+    font-weight: 700;
+}
+
+.h2 {
+    font-size: 2.2rem;
+    font-weight: 700;
+}
+
+.h3 {
+    font-size: 1.8rem;
+    font-weight: 700;
+}
+
+.h4 {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
+.h5 {
+    font-size: 1.2rem;
+    font-weight: 700;
+}
+
+.h6 {
+    font-size: 1.1rem;
+    color: var(--color-base-800);
+}

--- a/react-frontend/src/components/HTMLMarkdown/HeadingMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HeadingMarkdown.tsx
@@ -1,91 +1,26 @@
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './HTMLMarkdown.module.css';
 
 type HeadingMarkdownProps = React.HTMLAttributes<HTMLHRElement> & {
     headingNumber: "one" | "two" | "three" | "four" | "five" | "six",
 }
 
+const headingClass: Record<HeadingMarkdownProps["headingNumber"], string> = {
+    one: styles.h1,
+    two: styles.h2,
+    three: styles.h3,
+    four: styles.h4,
+    five: styles.h5,
+    six: styles.h6,
+}
+
 const HeadingMarkdown = ({ headingNumber, children, ...props }: HeadingMarkdownProps) => {
-    const { theme } = useThemeContext();
-    const HTMLHeadingStyles: Record<HeadingMarkdownProps["headingNumber"], React.CSSProperties> = {
-        one: {
-            fontSize: "3.8rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        two: {
-            fontSize: "2.2rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        three: {
-            fontSize: "1.8rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        four: {
-            fontSize: "1.4rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        five: {
-            fontSize: "1.2rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        six: {
-            fontSize: "1.1rem",
-            color: theme.colors.base[800]
-        }
-    }
     const HTMLHeadings: Record<HeadingMarkdownProps["headingNumber"], React.JSX.Element> = {
-        one:
-            <h1 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.one
-                }}>
-                {children}
-            </h1>,
-        two:
-            <h2 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.two
-                }}>
-                {children}
-            </h2>,
-        three:
-            <h3 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.three
-                }}>
-                {children}
-            </h3>,
-        four:
-            <h4 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.four
-                }}>
-                {children}
-            </h4>,
-        five:
-            <h5 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.five
-                }}>
-                {children}
-            </h5>,
-        six:
-            <h6 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.six
-                }}>
-                {children}
-            </h6>,
+        one: <h1 {...props} className={headingClass.one}>{children}</h1>,
+        two: <h2 {...props} className={headingClass.two}>{children}</h2>,
+        three: <h3 {...props} className={headingClass.three}>{children}</h3>,
+        four: <h4 {...props} className={headingClass.four}>{children}</h4>,
+        five: <h5 {...props} className={headingClass.five}>{children}</h5>,
+        six: <h6 {...props} className={headingClass.six}>{children}</h6>,
     }
 
     return HTMLHeadings[headingNumber];

--- a/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
@@ -1,18 +1,8 @@
-import { useMemo } from 'react';
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './HTMLMarkdown.module.css';
 
 const HrMarkdown = ({ ...props }: React.HTMLAttributes<HTMLHRElement>) => {
-    const { theme } = useThemeContext();
-    const elementStyle = useMemo(() => ({
-        margin: "1rem 0",
-        backgroundColor: theme.colors.base[200],
-        height: "1px",
-    }), [theme.colors.base]);
     return (
-        <div {...props} style={{
-            ...props.style,
-            ...elementStyle,
-        }} />
+        <div {...props} className={styles.hr} />
     )
 }
 

--- a/react-frontend/src/components/HTMLMarkdown/LiMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/LiMarkdown.tsx
@@ -1,22 +1,7 @@
-/** @jsxImportSource @emotion/react */
-
-import { Interpolation, Theme } from "@emotion/react"
-import { useMemo } from "react"
+import styles from './HTMLMarkdown.module.css';
 
 const LiMarkdown = ({ ...props }: React.HTMLAttributes<HTMLLIElement>) => {
-    const elementStyle = useMemo((): Interpolation<Theme> => ({
-        listStyleType: "none",
-        position: "relative",
-        "&::before": {
-            content: '">"',
-            position: "absolute",
-            top: 0,
-            left: -15,
-            fontWeight: 600
-        }
-    }), [])
-    
-    return (<li {...props} css={elementStyle}>
+    return (<li {...props} className={styles.li}>
         {props.children}
     </li>)
 }

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.module.css
@@ -1,0 +1,24 @@
+.highlightAreaBase {
+    font-weight: 600;
+    color: var(--color-base-800);
+    background: linear-gradient(to bottom, transparent 60%, var(--color-base-200) 60%);
+}
+
+.highlightAreaSecondary {
+    font-weight: 600;
+    color: var(--color-base-800);
+    background: linear-gradient(to bottom, transparent 60%, var(--color-secondary-300) 60%);
+}
+
+.highlightTextBase {
+    font-weight: 600;
+}
+
+.highlightTextSecondary {
+    font-weight: 600;
+    color: var(--color-secondary-500);
+}
+
+.button {
+    margin: 0.5rem;
+}

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -1,23 +1,32 @@
-import { CSSProperties, useMemo } from 'react';
-import { useThemeContext } from '../../contexts/ThemeContext';
+import { useMemo } from 'react';
 import type { Element, RootContent } from 'hast'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { markdownComponents } from '.';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import Button from '../Button';
 import { v4 as uuid } from 'uuid';
+import styles from './SpanMarkdown.module.css';
 
 
 type SpanElementType = "highlight-area" | "highlight-text";
 type SpanColorType = "base" | "secondary";
-type TargetElementType = Record<SpanElementType, Record<SpanColorType, CSSProperties>>;
 
 type SpanMarkdownProps = {
     node?: Element,
 } & React.HTMLAttributes<HTMLSpanElement>;
 
+const variantClass: Record<SpanElementType, Record<SpanColorType, string>> = {
+    "highlight-area": {
+        "base": styles.highlightAreaBase,
+        "secondary": styles.highlightAreaSecondary,
+    },
+    "highlight-text": {
+        "base": styles.highlightTextBase,
+        "secondary": styles.highlightTextSecondary,
+    },
+};
+
 const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
-    const { theme } = useThemeContext();
     const classes = useMemo(() => className?.split(" ") ?? [], [className]);
     const contentJSXElementsFromAST = useMemo(() => {
         const content = node?.children;
@@ -32,52 +41,18 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
             <Fragment key={uuid()}>{element}</Fragment>
         ));
     }, [node?.children]);
-    const targetElement = useMemo((): TargetElementType => ({
-        "highlight-area": {
-            "base": {
-                fontWeight: 600,
-                color: theme.colors.base[800],
-                background: `linear-gradient(to bottom, transparent 60%, ${theme.colors.base[200]} 60%)`,
-            },
-            "secondary": {
-                fontWeight: 600,
-                color: theme.colors.base[800],
-                background: `linear-gradient(to bottom, transparent 60%, ${theme.colors.secondary[300]} 60%)`
-            },
-        },
-        "highlight-text": {
-            "base": {
-                fontWeight: 600,
-            },
-            "secondary": {
-                color: theme.colors.secondary[500],
-                fontWeight: 600,
-            },
-        },
-    }), [theme.colors.base, theme.colors.secondary]);
     const spanElement = useMemo((): SpanElementType => {
         return classes.includes("highlight-area") ? "highlight-area" : "highlight-text";
     }, [classes]);
     const colorType = useMemo((): SpanColorType => {
         return classes.includes("secondary") ? "secondary" : "base";
     }, [classes]);
-    const { style, children } = useMemo((): { style: CSSProperties, children: React.ReactNode } => {
-        return {
-            style: {
-                ...props.style,
-                ...targetElement[spanElement][colorType],
-            },
-            children: contentJSXElementsFromAST
-        };
-    }, [props.style, contentJSXElementsFromAST, targetElement, spanElement, colorType]);
 
     // `[[Button]]`
     if (classes.includes("button")) {
         return (
             <Button
-                style={{
-                    margin: "0.5rem",
-                }}
+                className={styles.button}
                 key={classes.join()}
                 size='sm'>
                 {contentJSXElementsFromAST}
@@ -86,8 +61,8 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
     }
 
     return (
-        <span {...props} style={style}>
-            {children}
+        <span {...props} className={variantClass[spanElement][colorType]}>
+            {contentJSXElementsFromAST}
         </span>
     );
 }

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -20,9 +20,9 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
     const { theme } = useThemeContext();
     const classes = useMemo(() => className?.split(" ") ?? [], [className]);
     const contentJSXElementsFromAST = useMemo(() => {
-        let content = node?.children;
+        const content = node?.children;
         if (typeof content === 'string') return content;
-        let result = node?.children.map((element) => toJsxRuntime(element as RootContent, {
+        const result = node?.children.map((element) => toJsxRuntime(element as RootContent, {
             Fragment, jsx, jsxs, passNode: true, components: {
                 ...markdownComponents,
                 br: () => null,

--- a/react-frontend/src/components/HTMLMarkdown/UlMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/UlMarkdown.tsx
@@ -1,10 +1,8 @@
+import styles from './HTMLMarkdown.module.css';
+
 const UlMarkdown = ({ ...props }: React.HTMLAttributes<HTMLUListElement>) => {
     return (
-        <ul {...props}
-            style={{
-                ...props.style,
-                listStyleType: "none"
-            }} />
+        <ul {...props} className={styles.ul} />
     )
 }
 

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
@@ -7,7 +7,7 @@ export const customBlockquote = () => {
     return function (tree: Node) {
         visit(tree, 'blockquote', (node: Blockquote) => {
             findAndReplace(node, [
-                /\[!([^\[]+)\]\s?([a-z]*)/,
+                /\[!([^[]+)\]\s?([a-z]*)/,
                 (fullText, variation, titleText, matchedNode) => {
                     // To modfiy the parent node (Blockquote) of the matched text
                     matchedNode.stack[matchedNode.stack.length - 3].data = {

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customHighlightText.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customHighlightText.ts
@@ -1,7 +1,7 @@
 import { findAndReplace } from 'mdast-util-find-and-replace'
 import { visit } from 'unist-util-visit';
 import type { Node } from 'hast'
-import { Nodes, Parent } from 'mdast'
+import { Nodes, Parent, PhrasingContent } from 'mdast'
 import { toString } from 'mdast-util-to-string'
 
 const textVariationsRegexReplace = {
@@ -29,7 +29,7 @@ const handleVariationReplace = (variation: typeof textVariationsRegexReplace[key
     let isMatched = false;
     findAndReplace(node, [
         variation.regex,
-        (fullText: any, content: any) => {
+        (fullText: string, content: string) => {
             isMatched = true;
             return {
                 type: 'strong',
@@ -44,7 +44,7 @@ const handleVariationReplace = (variation: typeof textVariationsRegexReplace[key
                         className: variation.replace.className,
                     }
                 }
-            } as any;
+            } as unknown as PhrasingContent;
         }
     ])
     return isMatched;

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
@@ -3,7 +3,7 @@ import { Nodes, Parent, Image, RootContent } from 'mdast'
 import { toString } from 'mdast-util-to-string'
 
 
-let imageRegex = /!\[([^\]]+)\]\(([^ ]+)\s?(?:=(?:(\d+)x(\d+)|(h|w)(\d+)))?(?:\|(center|left|right))?\)/;
+const imageRegex = /!\[([^\]]+)\]\(([^ ]+)\s?(?:=(?:(\d+)x(\d+)|(h|w)(\d+)))?(?:\|(center|left|right))?\)/;
 
 const imageNodeStyle: React.CSSProperties = ({
     maxWidth: `inherit`,
@@ -50,7 +50,7 @@ const imageContainerStyle = (align: string): React.CSSProperties => {
 export const customImage = () => {
     return function (tree: Nodes) {
         visit(tree, 'paragraph', (node: Nodes) => {
-            let nodeFullText = toString(node);
+            const nodeFullText = toString(node);
             const match = imageRegex.exec(nodeFullText);
             if (match) {
                 const fragments = nodeFullText.split(imageRegex);

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureButton.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureButton.ts
@@ -3,7 +3,7 @@ import type { customType } from '.'
 
 export const captureButton = (node: Node): customType => ({
     regex: /\[\[([a-zA-Z0-9\s]+)\]\]/,
-    callback: (fullText: any, content: any) => {
+    callback: (fullText: string, content: string) => {
         return {
             type: 'strong',
             children: [

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
@@ -1,9 +1,10 @@
 import type { Node } from 'hast'
+import type { PhrasingContent } from 'mdast'
 import type { customType } from '.'
 
 export const captureGap = (node: Node): customType => ({
     regex: /\[gap\]/,
-    callback: (fullText: any) => ({
+    callback: (fullText: string) => ({
         type: 'paragraph',
         children: [],
         data: {
@@ -11,5 +12,5 @@ export const captureGap = (node: Node): customType => ({
                 style: "margin: 0 1rem 1rem 0; display: inline-block;"
             }
         }
-    } as any)
+    } as unknown as PhrasingContent)
 })

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
@@ -1,9 +1,10 @@
 import type { Node } from 'hast'
+import type { PhrasingContent } from 'mdast'
 import type { customType } from '.'
 
 export const captureNewline = (node: Node): customType => ({
     regex: /\[newline\]/,
-    callback: (fullText: any) => {
+    callback: (fullText: string) => {
         return ({
             type: 'paragraph',
             children: [],
@@ -12,6 +13,6 @@ export const captureNewline = (node: Node): customType => ({
                     style: "margin: 0.5rem 0; display: grid;"
                 }
             }
-        } as any)
+        } as unknown as PhrasingContent)
     }
 })

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureTextDirection.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureTextDirection.ts
@@ -3,7 +3,7 @@ import type { customType } from '.'
 
 export const captureTextDirection = (node: Node): customType => ({
     regex: /\[(center|left|right)\]/,
-    callback: (fullText: any, align: any) => {
+    callback: (fullText: string, align: string) => {
         node.data = {
             hProperties: {
                 style: "text-align: " + align

--- a/react-frontend/src/components/Icon/Icon.module.css
+++ b/react-frontend/src/components/Icon/Icon.module.css
@@ -1,0 +1,65 @@
+.icon {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: center;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    background-color: var(--color-base-50);
+    color: var(--color-base-700);
+    transition: var(--transition);
+    cursor: default;
+}
+
+.icon:hover {
+    transform: scale(1.05);
+}
+
+.icon:active {
+    transform: scale(0.95);
+    color: var(--color-base-200);
+    background-color: var(--color-base-600);
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+.lg {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+}
+
+.md {
+    padding: 0.4rem 0.9rem;
+    font-size: 0.8rem;
+}
+
+.imageFrame {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--color-base-50);
+    border: var(--border);
+    overflow: hidden;
+    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.2));
+}
+
+.lg .imageFrame {
+    width: 70px;
+    height: 70px;
+}
+
+.md .imageFrame {
+    width: 50px;
+    height: 50px;
+}
+
+.image {
+    width: 70%;
+    object-fit: cover;
+    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.5));
+}

--- a/react-frontend/src/components/Icon/index.tsx
+++ b/react-frontend/src/components/Icon/index.tsx
@@ -1,24 +1,6 @@
-/** @jsxImportSource @emotion/react */
-
-import { CSSProperties, useCallback, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Text from '../Text';
-import { css } from '@emotion/react';
-
-const variants = {
-    "lg": {
-        outerPadding: "0.5rem 1rem",
-        imageWidth: "70px",
-        imageHeight: "70px",
-        fontSize: "1rem",
-    },
-    "md": {
-        outerPadding: "0.4rem 0.9rem",
-        imageWidth: "50px",
-        imageHeight: "50px",
-        fontSize: "0.8rem",
-    },
-}
+import { cx } from '../../utils/cx';
+import styles from './Icon.module.css';
 
 type IconProps = {
     readonly src?: string;
@@ -26,8 +8,8 @@ type IconProps = {
     readonly text?: string;
     readonly pointer?: boolean;
     readonly onClick?: () => void;
-    readonly size?: keyof typeof variants;
-}
+    readonly size?: 'lg' | 'md';
+};
 
 export default function Icon({
     src,
@@ -35,52 +17,27 @@ export default function Icon({
     text,
     pointer = false,
     onClick,
-    size = "md"
+    size = 'md',
 }: IconProps) {
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo(() => css({
-        flexDirection: "column",
-        padding: variants[size].outerPadding,
-        cursor: pointer ? "pointer" : "default",
-        fontSize: variants[size].fontSize,
-        ...theme.button,
-    }), [theme, pointer, size]);
-    const imageFrameStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: variants[size].imageWidth,
-            height: variants[size].imageHeight,
-            borderRadius: "50%",
-            backgroundColor: theme.colors.base[50],
-            border: theme.border,
-            overflow: "hidden",
-            filter: "drop-shadow(0px 0px 2px rgba(0,0,0,0.2))",
-        };
-    }, [theme, size]);
-    const imageStyle = useMemo((): CSSProperties => {
-        return {
-            width: "70%",
-            objectFit: "cover",
-            filter: "drop-shadow(0px 0px 2px rgba(0,0,0,0.5))",
-        };
-    }, []);
-    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === "Enter") {
-            onClick?.();
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (onClick && (event.key === 'Enter' || event.key === ' ')) {
+            event.preventDefault();
+            onClick();
         }
-    }, [onClick]);
+    };
 
     return (
         <div
-            css={outerStyle}
+            className={cx(styles.icon, styles[size], pointer && styles.pointer)}
             onClick={onClick}
-            onKeyDown={handleKeyDown} >
-            <div style={imageFrameStyle}>
-                <img style={imageStyle} src={src ?? "images/placeholder.png"} alt={alt} />
+            onKeyDown={handleKeyDown}
+            role={onClick ? 'button' : undefined}
+            tabIndex={onClick ? 0 : undefined}
+        >
+            <div className={styles.imageFrame}>
+                <img className={styles.image} src={src ?? 'images/placeholder.png'} alt={alt} />
             </div>
-            {text && <Text variant={"body"}>{text}</Text>}
+            {text && <Text variant={'body'}>{text}</Text>}
         </div>
-    )
+    );
 }

--- a/react-frontend/src/components/ListButtons.module.css
+++ b/react-frontend/src/components/ListButtons.module.css
@@ -1,0 +1,7 @@
+.list {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 1rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/components/ListButtons.tsx
+++ b/react-frontend/src/components/ListButtons.tsx
@@ -1,23 +1,13 @@
-import { CSSProperties, useMemo } from 'react';
 import Button from './Button'
+import styles from './ListButtons.module.css';
 
 type ListButtonsProps = {
     readonly elements: string[];
 }
 
 export default function ListButtons({ elements }: ListButtonsProps) {
-    const mainListStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap",
-        }
-    }, []);
-
     return (
-        <div style={mainListStyle}>
+        <div className={styles.list}>
             {elements.map((tech) => {
                 return (
                     <Button key={tech} text={tech} size='sm' />

--- a/react-frontend/src/components/Loader/Loader.module.css
+++ b/react-frontend/src/components/Loader/Loader.module.css
@@ -1,0 +1,9 @@
+.loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.spinner {
+    color: var(--color-base-700);
+}

--- a/react-frontend/src/components/Loader/index.tsx
+++ b/react-frontend/src/components/Loader/index.tsx
@@ -1,24 +1,11 @@
-import { useMemo } from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './Loader.module.css';
 
 export default function Loader() {
-    const { theme } = useThemeContext();
-
-    const containerStyle = useMemo(() => ({
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-    }), []);
-
     return (
-        <div style={containerStyle}>
-            <FontAwesomeIcon
-            style={{
-                color: theme.colors.base[700],
-            }}
-            icon={faSpinner} size="2x" spin />
+        <div className={styles.loader}>
+            <FontAwesomeIcon className={styles.spinner} icon={faSpinner} size="2x" spin />
         </div>
     )
 }

--- a/react-frontend/src/components/MainSection/Content.module.css
+++ b/react-frontend/src/components/MainSection/Content.module.css
@@ -1,0 +1,10 @@
+.content {
+    display: flex;
+    justify-content: flex-start;
+    gap: 1rem;
+    align-items: stretch;
+}
+
+.grow {
+    flex-grow: 1;
+}

--- a/react-frontend/src/components/MainSection/Content.tsx
+++ b/react-frontend/src/components/MainSection/Content.tsx
@@ -1,24 +1,13 @@
-import { CSSProperties, useMemo } from 'react'
+import styles from './Content.module.css';
 
 type ContentProps = {
     readonly children: React.ReactNode,
 }
 
 export default function Content({ children }: ContentProps) {
-    const mainStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            alignItems: "stretch",
-        }
-    }, []);
-
     return (
-        <main style={mainStyle}>
-            <div style={{
-                flexGrow: 1,
-            }}>
+        <main className={styles.content}>
+            <div className={styles.grow}>
                 {children}
             </div>
         </main>

--- a/react-frontend/src/components/MainSection/Header.module.css
+++ b/react-frontend/src/components/MainSection/Header.module.css
@@ -1,8 +1,5 @@
 .headerContainer {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
+    display: inline;
 }
 
 .headerText {

--- a/react-frontend/src/components/MainSection/Header.module.css
+++ b/react-frontend/src/components/MainSection/Header.module.css
@@ -1,12 +1,12 @@
 .headerContainer {
-    display: inline;
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
 }
 
 .headerText {
     display: inline;
-    margin-right: 0.5rem;
 }
 
 .linkText {

--- a/react-frontend/src/components/MainSection/Header.module.css
+++ b/react-frontend/src/components/MainSection/Header.module.css
@@ -1,0 +1,18 @@
+.headerContainer {
+    display: inline;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.headerText {
+    display: inline;
+    margin-right: 0.5rem;
+}
+
+.linkText {
+    display: inline-block;
+}
+
+.pointer {
+    cursor: pointer;
+}

--- a/react-frontend/src/components/MainSection/Header.tsx
+++ b/react-frontend/src/components/MainSection/Header.tsx
@@ -5,6 +5,9 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { cx } from '../../utils/cx';
 import styles from './Header.module.css';
 
+const titleTextStyle = { display: 'inline', marginRight: '0.5rem' } as const;
+const iconTextStyle = { display: 'inline-block' } as const;
+
 type HeaderProps = {
     readonly title: string,
     readonly link?: string,
@@ -24,13 +27,14 @@ export default function Header({ title, link, subtitle }: HeaderProps) {
                 <Text
                     variant={"h3"}
                     onClick={link ? headerOnCLickHandler : undefined}
-                    style={undefined}>
+                    style={titleTextStyle}>
                     <span className={cx(styles.headerText, link && styles.pointer)}>{title}</span>
                 </Text>
                 {link && (
                     <Text
                         variant={"h3"}
-                        onClick={headerOnCLickHandler}>
+                        onClick={headerOnCLickHandler}
+                        style={iconTextStyle}>
                         <span className={cx(styles.linkText, styles.pointer)}>
                             <ExternalLinkIcon />
                         </span>

--- a/react-frontend/src/components/MainSection/Header.tsx
+++ b/react-frontend/src/components/MainSection/Header.tsx
@@ -1,7 +1,9 @@
-import { CSSProperties, useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import Text from '../Text';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { cx } from '../../utils/cx';
+import styles from './Header.module.css';
 
 type HeaderProps = {
     readonly title: string,
@@ -10,45 +12,28 @@ type HeaderProps = {
 }
 
 export default function Header({ title, link, subtitle }: HeaderProps) {
-    const headerConatinerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "inline",
-            alignItems: "center",
-            gap: "0.5rem",
-        }
-    }, []);
-
-    const headerTextStyle = useMemo((): CSSProperties => {
-        return {
-            // color: theme.colors.base[600],
-            display: "inline",
-            marginRight: "0.5rem",
-            cursor: link ? "pointer" : "default",
-        }
-    }, [link]);
-
     const headerOnCLickHandler = useCallback(() => {
-        link && window.open(link, "_blank");
+        if (link) {
+            window.open(link, "_blank");
+        }
     }, [link]);
 
     return (
         <>
-            <div style={headerConatinerStyle}>
+            <div className={styles.headerContainer}>
                 <Text
                     variant={"h3"}
-                    onClick={headerOnCLickHandler}
-                    style={headerTextStyle}>
-                    {title}
+                    onClick={link ? headerOnCLickHandler : undefined}
+                    style={undefined}>
+                    <span className={cx(styles.headerText, link && styles.pointer)}>{title}</span>
                 </Text>
                 {link && (
                     <Text
                         variant={"h3"}
-                        onClick={headerOnCLickHandler}
-                        style={{
-                            display: "inline-block",
-                            cursor: link ? "pointer" : "default",
-                            }}>
-                        <ExternalLinkIcon />
+                        onClick={headerOnCLickHandler}>
+                        <span className={cx(styles.linkText, styles.pointer)}>
+                            <ExternalLinkIcon />
+                        </span>
                     </Text>
                 )}
             </div>

--- a/react-frontend/src/components/MainSection/HeaderSymbol.module.css
+++ b/react-frontend/src/components/MainSection/HeaderSymbol.module.css
@@ -1,0 +1,17 @@
+.symbol {
+    width: 20px;
+    height: 20px;
+    background-color: var(--color-base-50);
+    border: var(--border);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dot {
+    width: 70%;
+    height: 70%;
+    border-radius: 50%;
+    background-color: var(--color-base-500);
+}

--- a/react-frontend/src/components/MainSection/HeaderSymbol.tsx
+++ b/react-frontend/src/components/MainSection/HeaderSymbol.tsx
@@ -1,28 +1,9 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './HeaderSymbol.module.css';
 
 export default function HeaderSymbol() {
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo((): CSSProperties => ({
-        width: "20px",
-        height: "20px",
-        backgroundColor: theme.colors.base[50],
-        border: theme.border,
-        borderRadius: "50%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-    }), [theme]);
-    const innerStyle = useMemo((): CSSProperties => ({
-        width: "70%",
-        height: "70%",
-        borderRadius: "50%",
-        backgroundColor: theme.colors.base[500],
-    }), [theme]);
-
     return (
-        <div style={outerStyle}>
-            <div style={innerStyle} />
+        <div className={styles.symbol}>
+            <div className={styles.dot} />
         </div>
     )
 }

--- a/react-frontend/src/components/MainSection/index.tsx
+++ b/react-frontend/src/components/MainSection/index.tsx
@@ -1,7 +1,7 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Header from './Header';
 import Content from './Content';
+import { cx } from '../../utils/cx';
+import surfaces from '../../styles/surfaces.module.css';
 
 type MainSectionProps = {
     readonly title?: string,
@@ -14,17 +14,8 @@ type MainSectionProps = {
 export default function MainSection({ title, link, subtitle, style, children }:
     MainSectionProps
 ) {
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            ...theme.container,
-            flexDirection: "column",
-            ...style,
-        }
-    }, [theme, style]);
-
     return (
-        <div style={containerStyle}>
+        <div className={cx(surfaces.container, surfaces.column)} style={style}>
             {title && <Header title={title} link={link} subtitle={subtitle} />}
             <Content>
                 {children}

--- a/react-frontend/src/components/Navbar/Links/LinkButton.module.css
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.module.css
@@ -1,0 +1,3 @@
+.link {
+    font-weight: 500;
+}

--- a/react-frontend/src/components/Navbar/Links/LinkButton.tsx
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.tsx
@@ -2,7 +2,7 @@ import Button from '../../Button'
 import { PortfolioPathes } from '../../../Types';
 import { memo, useMemo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './LinkButton.module.css';
 
 type LinkButtonProps = {
     readonly path: PortfolioPathes,
@@ -11,23 +11,23 @@ type LinkButtonProps = {
 }
 
 function LinkButton({ path, pageName, onClick }: LinkButtonProps) {
-    const { theme } = useThemeContext();
     const navigate = useNavigate();
     const active = useMatch(`/${path}`);
+    // Active/inactive colours depend on the current route, so they stay as
+    // token-based inline styles; the ghost variant strips the default border/shadow.
     const linkButtonStyle = useMemo(() => {
         const linkActive = active !== null;
         return {
-            boxShadow: "none",
-            border: "none",
-            backgroundColor: linkActive ? theme.colors.base[200] : "",
-            color: linkActive ? theme.colors.base[800] : theme.colors.base[400],
-            opacity: linkActive ? "1" : "0.9",
-            fontWeight: "500",
-        }
-    }, [theme.colors.base, active]);
+            backgroundColor: linkActive ? 'var(--color-base-200)' : 'transparent',
+            color: linkActive ? 'var(--color-base-800)' : 'var(--color-base-400)',
+            opacity: linkActive ? 1 : 0.9,
+        };
+    }, [active]);
 
     return (
         <Button
+            variant="ghost"
+            className={styles.link}
             style={linkButtonStyle}
             pointer={true}
             size='md'

--- a/react-frontend/src/components/Navbar/Links/NormalLinks/NormalLinks.module.css
+++ b/react-frontend/src/components/Navbar/Links/NormalLinks/NormalLinks.module.css
@@ -1,0 +1,6 @@
+.links {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}

--- a/react-frontend/src/components/Navbar/Links/NormalLinks/index.tsx
+++ b/react-frontend/src/components/Navbar/Links/NormalLinks/index.tsx
@@ -1,16 +1,9 @@
-import { useMemo } from 'react';
 import PortfolioLinks from '../PortfolioLinks';
+import styles from './NormalLinks.module.css';
 
 export default function NormalLinks() {
-    const linksContainerStyle = useMemo(() => ({
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: "1rem",
-    }), []);
-
     return (
-        <div style={linksContainerStyle}>
+        <div className={styles.links}>
             <PortfolioLinks />
         </div>
     )

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.module.css
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.module.css
@@ -1,0 +1,5 @@
+.bars {
+    display: inline-block;
+    color: var(--color-base-400);
+    cursor: pointer;
+}

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.tsx
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.tsx
@@ -1,27 +1,31 @@
-import { useThemeContext } from '../../../../contexts/ThemeContext';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBars } from '@fortawesome/free-solid-svg-icons';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
+import styles from './BarsIcon.module.css';
 
 type BarsIconProps = {
     readonly setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 function BarsIcon({ setIsMenuOpen }: BarsIconProps) {
-    const { theme } = useThemeContext();
-    const barsStyle = useMemo(() => ({
-        display: "inline-block",
-        color: theme.colors.base[400],
-        cursor: "pointer",
-    }), [theme.colors]);
     const clickHandler = useCallback(() => {
         setIsMenuOpen((oldIsMenuOpen) => !oldIsMenuOpen);
     }, [setIsMenuOpen]);
+    const keyDownHandler = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            clickHandler();
+        }
+    }, [clickHandler]);
 
     return (
         <div
-            style={barsStyle}
-            onClick={clickHandler} >
+            className={styles.bars}
+            role="button"
+            tabIndex={0}
+            aria-label="Open navigation menu"
+            onClick={clickHandler}
+            onKeyDown={keyDownHandler} >
             <FontAwesomeIcon icon={faBars} size={"xl"} />
         </div>
     )

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/DropDownLinks.module.css
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/DropDownLinks.module.css
@@ -1,0 +1,32 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    transform-origin: top;
+    transition: var(--transition);
+}
+
+.overlayOpen {
+    left: 0;
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    background-color: var(--color-base-50);
+}

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.module.css
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.module.css
@@ -1,0 +1,7 @@
+.exit {
+    width: fit-content;
+    margin: 0 auto;
+    border-radius: 50%;
+    padding: 0.7rem;
+    color: var(--color-base-600);
+}

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.tsx
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.tsx
@@ -1,30 +1,21 @@
-import { useCallback, useMemo } from 'react'
 import Button from '../../../../Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
-import { useThemeContext } from '../../../../../contexts/ThemeContext';
+import styles from './ExitButton.module.css';
 
 type ExitButtonProps = {
     readonly setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export default function ExitButton({ setIsMenuOpen }: ExitButtonProps) {
-    const { theme } = useThemeContext();
-    const buttonStyle = useMemo(() => ({
-        width: 'fit-content',
-        margin: '0 auto',
-        cursor: 'pointer',
-        borderRadius: '50%',
-        padding: '0.7rem',
-        color: theme.colors.base[600],
-    }), [theme.colors]);
-    const buttonClickHandler = useCallback(() => {
+    const buttonClickHandler = () => {
         setIsMenuOpen(false);
-    }, [setIsMenuOpen]);
+    };
 
     return (
         <Button
-            style={buttonStyle}
+            className={styles.exit}
+            pointer={true}
             icon={<FontAwesomeIcon icon={faCircleXmark} transform="grow-12" />}
             onClick={buttonClickHandler} />
     )

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/index.tsx
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/index.tsx
@@ -1,8 +1,8 @@
-import { CSSProperties, useCallback, useMemo } from "react";
-import { useThemeContext } from '../../../../../contexts/ThemeContext';
 import PortfolioLinks from "../../PortfolioLinks";
 import BlurBackground from "../../../../BlurBackground";
 import ExitButton from "./ExitButton";
+import { cx } from "../../../../../utils/cx";
+import styles from "./DropDownLinks.module.css";
 
 type DropDownLinksProps = {
     readonly isMenuOpen: boolean,
@@ -10,41 +10,15 @@ type DropDownLinksProps = {
 }
 
 export default function DropDownLinks({ isMenuOpen, setIsMenuOpen }: DropDownLinksProps) {
-    const { theme } = useThemeContext();
-    const linksContainerStyle = useMemo((): CSSProperties => ({
-        position: "fixed",
-        top: "0",
-        right: "0",
-        left: isMenuOpen ? "0" : "100%",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        gap: "1rem",
-        padding: "2rem",
-        width: "100%",
-        overflow: "hidden",
-        transformOrigin: "top",
-        transition: theme.transition,
-        height: '100%',
-    }), [isMenuOpen, theme.transition]);
-    const linkButtonsContainerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        gap: "1rem",
-        ...theme.boxingStyle,
-        backgroundColor: theme.colors.base[50],
-        padding: "2rem",
-    }), [theme.boxingStyle, theme.colors]);
-    const linkButtonOnClickHandler = useCallback(() => {
+    const linkButtonOnClickHandler = () => {
         setIsMenuOpen(false);
-    }, [setIsMenuOpen]);
+    };
 
     return (
-        <div style={linksContainerStyle}>
-            <BlurBackground backgroundColor={theme.colors.base[400]} />
+        <div className={cx(styles.overlay, isMenuOpen && styles.overlayOpen)}>
+            <BlurBackground backgroundColor={'var(--color-base-400)'} />
             <ExitButton setIsMenuOpen={setIsMenuOpen} />
-            <div style={linkButtonsContainerStyle}>
+            <div className={styles.panel}>
                 <PortfolioLinks
                     linkButtonOnClickHandler={linkButtonOnClickHandler} />
             </div>

--- a/react-frontend/src/components/Navbar/Logo.module.css
+++ b/react-frontend/src/components/Navbar/Logo.module.css
@@ -1,0 +1,9 @@
+.logo {
+    color: var(--color-base-100);
+    cursor: pointer;
+}
+
+.text {
+    font-size: 1.5rem;
+    font-weight: 700;
+}

--- a/react-frontend/src/components/Navbar/Logo.tsx
+++ b/react-frontend/src/components/Navbar/Logo.tsx
@@ -1,11 +1,10 @@
 import { useCallback } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Text from '../Text'
 import { SanityNavbarData } from '../../Types';
 import { useNavigate } from 'react-router-dom';
+import styles from './Logo.module.css';
 
 export default function Logo({ logo }: Readonly<Pick<SanityNavbarData, "logo">>) {
-    const { theme } = useThemeContext();
     const navigate = useNavigate();
 
     const changeLinksHandler = useCallback(() => navigate(''), [navigate]);
@@ -17,17 +16,13 @@ export default function Logo({ logo }: Readonly<Pick<SanityNavbarData, "logo">>)
 
     return (
         <div
-            style={{
-                color: theme.colors.base[100],
-                cursor: "pointer",
-            }}
+            className={styles.logo}
+            role="button"
+            tabIndex={0}
             onClick={changeLinksHandler}
             onKeyDown={onKeyDownHandler} >
-            <Text variant={"h2"} style={{
-                fontSize: "1.5rem",
-                fontWeight: "700",
-            }}>
-                {logo}
+            <Text variant={"h2"}>
+                <span className={styles.text}>{logo}</span>
             </Text>
         </div>
     )

--- a/react-frontend/src/components/Navbar/Navbar.module.css
+++ b/react-frontend/src/components/Navbar/Navbar.module.css
@@ -1,0 +1,21 @@
+.navbar {
+    position: sticky;
+    padding: 1rem;
+    max-width: 1255px;
+    top: 20px;
+    z-index: 999;
+    background-color: var(--color-base-900);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+    max-width: 1255px;
+    margin: 0 auto;
+    padding: 0 1rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/components/Navbar/index.tsx
+++ b/react-frontend/src/components/Navbar/index.tsx
@@ -1,44 +1,17 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Logo from './Logo'
 import Links from './Links';
 import { SanityNavbarData } from '../../Types';
 import { getNavbarData } from '../../APIs';
 import Loader from '../Loader';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from './Navbar.module.css';
 
 export default function Navbar() {
-    const [navbarData, setNavbarData] = useState<SanityNavbarData | null>(null);
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo((): CSSProperties => ({
-        position: "sticky",
-        padding: "1rem",
-        maxWidth: "1255px",
-        top: "20px",
-        zIndex: "999",
-        backgroundColor: theme.colors.base[900],
-        ...theme.boxingStyle,
-        border: "none",
-    }), [theme]);
-    const innerStyle = useMemo((): CSSProperties => ({
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        height: "100%",
-        maxWidth: "1255px",
-        margin: "0 auto",
-        padding: "0 1rem",
-        flexWrap: "wrap",
-    }), []);
-
-    useEffect(() => {
-        getNavbarData().then((data) => {
-            setNavbarData(data);
-        });
-    }, []);
+    const { data: navbarData } = useSanityQuery<SanityNavbarData>(getNavbarData);
 
     return (
-        <div style={outerStyle}>
-            <div style={innerStyle}>
+        <div className={styles.navbar}>
+            <div className={styles.inner}>
                 {navbarData ? <Logo logo={navbarData.logo} /> : <Loader />}
                 <Links />
             </div>

--- a/react-frontend/src/components/ProjectCard/Content.module.css
+++ b/react-frontend/src/components/ProjectCard/Content.module.css
@@ -1,0 +1,12 @@
+.content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.links {
+    display: flex;
+    gap: 1rem;
+}

--- a/react-frontend/src/components/ProjectCard/Content.tsx
+++ b/react-frontend/src/components/ProjectCard/Content.tsx
@@ -1,8 +1,9 @@
-import { CSSProperties, memo, useMemo } from 'react'
+import { memo } from 'react'
 import ListButtons from '../ListButtons';
 import ProjectButton from './Image/ImageOverlay/ProjectButton';
 import DemoButton from './Image/ImageOverlay/DemoButton';
 import HTMLMarkdown from '../HTMLMarkdown';
+import styles from './Content.module.css';
 
 type ContentProps = {
     readonly title?: string,
@@ -13,24 +14,10 @@ type ContentProps = {
 }
 
 function Content({ title, description, technologies, projectLink, demoLink }: ContentProps) {
-    const outerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            justifyContent: "space-between",
-            gap: "1rem",
-        }
-    }, []);
-    const linksStyle = useMemo(() => ({
-        display: "flex",
-        gap: "1rem",
-    }), []);
-
     return (
-        <div style={outerStyle}>
+        <div className={styles.content}>
             <HTMLMarkdown markdown={description} />
-            <div style={linksStyle}>
+            <div className={styles.links}>
                 {projectLink && <ProjectButton projectLink={projectLink} />}
                 {demoLink && <DemoButton demoLink={demoLink} />}
             </div>

--- a/react-frontend/src/components/ProjectCard/Image/Image.module.css
+++ b/react-frontend/src/components/ProjectCard/Image/Image.module.css
@@ -1,0 +1,17 @@
+.frame {
+    max-width: 350px;
+    height: auto;
+    overflow: hidden;
+    border-radius: var(--radius);
+    border: var(--border);
+    box-shadow: var(--shadow);
+    position: relative;
+    flex: 0 0 auto;
+}
+
+@media (max-width: 768px) {
+    .frame {
+        max-width: 100%;
+        height: 250px;
+    }
+}

--- a/react-frontend/src/components/ProjectCard/Image/ImageOverlay/ImageOverlay.module.css
+++ b/react-frontend/src/components/ProjectCard/Image/ImageOverlay/ImageOverlay.module.css
@@ -1,0 +1,22 @@
+.overlay {
+    z-index: 1;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    transition: var(--transition);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    border-radius: var(--radius);
+}
+
+.overlayHovered {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/react-frontend/src/components/ProjectCard/Image/ImageOverlay/index.tsx
+++ b/react-frontend/src/components/ProjectCard/Image/ImageOverlay/index.tsx
@@ -1,34 +1,16 @@
-/** @jsxImportSource @emotion/react */
-
-import { useMemo, CSSProperties, memo } from 'react'
-import { useThemeContext } from '../../../../contexts/ThemeContext';
+import { memo } from 'react'
 import BlurBackground from '../../../BlurBackground';
+import { cx } from '../../../../utils/cx';
+import styles from './ImageOverlay.module.css';
 
 type ImageOverlayProps = {
     readonly isHovered: boolean,
 }
 
 function ImageOverlay({ isHovered }: ImageOverlayProps) {
-    const { theme } = useThemeContext();
-    const imageOverlayStyle = useMemo((): CSSProperties => ({
-        zIndex: 1,
-        position: "absolute",
-        top: isHovered ? 0 : "50%",
-        left: isHovered ? 0 : "50%",
-        width: isHovered ? "100%" : "0%",
-        height: isHovered ? "100%" : "0%",
-        overflow: "hidden",
-        transition: theme.transition,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "1rem",
-        borderRadius: theme.borderRadius,
-    }), [theme, isHovered]);
-
     return (
-        <div style={imageOverlayStyle}>
-            <BlurBackground backgroundColor={theme.colors.base[700]} />
+        <div className={cx(styles.overlay, isHovered && styles.overlayHovered)}>
+            <BlurBackground backgroundColor={'var(--color-base-700)'} />
         </div>
     )
 }

--- a/react-frontend/src/components/ProjectCard/Image/MainImage.module.css
+++ b/react-frontend/src/components/ProjectCard/Image/MainImage.module.css
@@ -1,0 +1,6 @@
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: var(--transition);
+}

--- a/react-frontend/src/components/ProjectCard/Image/MainImage.tsx
+++ b/react-frontend/src/components/ProjectCard/Image/MainImage.tsx
@@ -1,18 +1,11 @@
 import { memo } from "react"
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './MainImage.module.css';
 
 function MainImage({ imgSrc, isHovered }: { imgSrc: string, isHovered: boolean }) {
-    const { theme } = useThemeContext();
-
     return (
         <img
-            style={{ 
-                transition: theme.transition ,
-                width: "100%", 
-                height: "100%", 
-                objectFit: "cover", 
-                scale: isHovered ? "1.2" : "1"
-            }}
+            className={styles.image}
+            style={{ scale: isHovered ? "1.2" : "1" }}
             src={imgSrc}
             alt={imgSrc} />
     )

--- a/react-frontend/src/components/ProjectCard/Image/index.tsx
+++ b/react-frontend/src/components/ProjectCard/Image/index.tsx
@@ -1,28 +1,13 @@
-import { useState, useMemo, CSSProperties } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext';
-// import ImageOverlay from './ImageOverlay';
+import { useState } from 'react'
 import MainImage from './MainImage';
+import styles from './Image.module.css';
 
 export type ImageProps = {
     readonly imgSrc: string,
-    readonly isSmallScreen: boolean,
 }
 
-export default function Image({ imgSrc, isSmallScreen }: ImageProps) {
+export default function Image({ imgSrc }: ImageProps) {
     const [isHovered, setIsHovered] = useState(false);
-    const { theme } = useThemeContext();
-    const imageFrameStyle = useMemo((): CSSProperties => {
-        return {
-            maxWidth: isSmallScreen ? "100%" : "350px",
-            height: isSmallScreen ? "250px" : "auto",
-            overflow: "hidden",
-            borderRadius: theme.borderRadius,
-            border: `1px solid ${theme.colors.base}`,
-            boxShadow: theme.boxShadow,
-            position: "relative",
-            flex: "0 0 auto"
-        }
-    }, [theme, isSmallScreen]);
 
     return (
         <div
@@ -30,9 +15,8 @@ export default function Image({ imgSrc, isSmallScreen }: ImageProps) {
             onFocus={() => { setIsHovered(true) }}
             onMouseOut={() => { setIsHovered(false) }}
             onBlur={() => { setIsHovered(false) }}
-            style={imageFrameStyle} >
+            className={styles.frame} >
             <MainImage imgSrc={imgSrc} isHovered={isHovered} />
-            {/* <ImageOverlay isHovered={isHovered} /> */}
         </div>
     )
 }

--- a/react-frontend/src/components/ProjectCard/ProjectCard.module.css
+++ b/react-frontend/src/components/ProjectCard/ProjectCard.module.css
@@ -1,0 +1,12 @@
+.card {
+    align-items: stretch;
+    justify-content: flex-start;
+    flex-direction: row;
+    height: auto;
+}
+
+@media (max-width: 768px) {
+    .card {
+        flex-direction: column;
+    }
+}

--- a/react-frontend/src/components/ProjectCard/index.tsx
+++ b/react-frontend/src/components/ProjectCard/index.tsx
@@ -1,8 +1,9 @@
-import { CSSProperties, memo, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
-import { useMediaQuery } from 'react-responsive';
+import { memo } from 'react'
 import Image from './Image';
 import Content from './Content';
+import { cx } from '../../utils/cx';
+import surfaces from '../../styles/surfaces.module.css';
+import styles from './ProjectCard.module.css';
 
 type ProjectCardProps = {
     readonly imgSrc?: string,
@@ -21,23 +22,9 @@ function ProjectCard({
     description,
     technologies
 }: ProjectCardProps) {
-    const { theme } = useThemeContext();
-    const isSmallScreen = useMediaQuery({ query: '(max-width: 768px)' });
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            alignItems: "stretch",
-            justifyContent: "flex-start",
-            flexDirection: isSmallScreen ? "column" : "row",
-            height: "auto",
-            ...theme.container,
-        }
-    }, [theme, isSmallScreen]);
-
     return (
-        <div style={containerStyle}>
-            <Image
-                imgSrc={imgSrc || "images/placeholder.png"}
-                isSmallScreen={isSmallScreen} />
+        <div className={cx(surfaces.container, styles.card)}>
+            <Image imgSrc={imgSrc || "images/placeholder.png"} />
             <Content 
                 description={description} 
                 technologies={technologies}

--- a/react-frontend/src/components/SectionError/SectionError.module.css
+++ b/react-frontend/src/components/SectionError/SectionError.module.css
@@ -1,0 +1,5 @@
+.error {
+    text-align: center;
+    color: var(--color-base-600);
+    padding: 2rem;
+}

--- a/react-frontend/src/components/SectionError/index.tsx
+++ b/react-frontend/src/components/SectionError/index.tsx
@@ -1,0 +1,15 @@
+import styles from './SectionError.module.css';
+
+type SectionErrorProps = {
+    readonly message?: string;
+};
+
+export default function SectionError({
+    message = 'Something went wrong loading this section. Please try again later.',
+}: SectionErrorProps) {
+    return (
+        <p className={styles.error} role="alert">
+            {message}
+        </p>
+    );
+}

--- a/react-frontend/src/components/SectionTitle/SectionTitle.module.css
+++ b/react-frontend/src/components/SectionTitle/SectionTitle.module.css
@@ -1,0 +1,21 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    text-align: center;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    font-size: 1.2rem;
+    flex-wrap: wrap;
+}
+
+.text {
+    color: var(--color-base-800);
+}

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/ActualText.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/ActualText.tsx
@@ -1,20 +1,9 @@
 import Text from '../../Text'
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext'
+import styles from './highlight.module.css';
 
 function ActualText({ text }: { readonly text: string }) {
-    const { theme } = useThemeContext();
-    const style = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        borderRadius: "inherit",
-        backgroundColor: theme.colors.secondary[300],
-        padding: "10px 1.4rem",
-    }), [theme.colors]);
-    
     return (
-        <div style={style}>
+        <div className={styles.actual}>
             <Text variant={"h2"}>{text}</Text>
         </div>
     );

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/Shadow.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/Shadow.tsx
@@ -1,23 +1,8 @@
-import { CSSProperties, useMemo } from 'react';
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './highlight.module.css';
 
 function Shadow() {
-    const { theme } = useThemeContext();
-
-    const style = useMemo((): CSSProperties => ({
-        width: "inherit",
-        height: "inherit",
-        position: "absolute",
-        zIndex: "-2",
-        backgroundColor: theme.colors.base[800],
-        bottom: "-3px",
-        left: "3px",
-        margin: "auto",
-        borderRadius: "inherit", 
-    }), []);
-    
     return (
-        <div style={style} />
+        <div className={styles.shadow} />
     );
 }
 

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/Stroke.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/Stroke.tsx
@@ -1,22 +1,8 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext'
+import styles from './highlight.module.css';
 
 function Stroke() {
-    const { theme } = useThemeContext();
-    const style = useMemo((): CSSProperties => ({
-        width: "calc(100% - 10px)",
-        height: "calc(100% - 10px)",
-        position: "absolute",
-        zIndex: "1",
-        border: `3px solid ${theme.colors.base[800]}`,
-        top: "5px",
-        left: "5px",
-        margin: "auto",
-        borderRadius: "inherit", 
-    }), [theme.colors]);
-    
     return (
-        <div style={style} />
+        <div className={styles.stroke} />
     );
 }
 

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/highlight.module.css
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/highlight.module.css
@@ -1,0 +1,41 @@
+.highlight {
+    color: var(--color-base-900);
+    box-shadow: var(--shadow);
+    position: relative;
+    rotate: -3deg;
+    z-index: 1;
+    border-radius: var(--radius);
+}
+
+.shadow {
+    width: inherit;
+    height: inherit;
+    position: absolute;
+    z-index: -2;
+    background-color: var(--color-base-800);
+    bottom: -3px;
+    left: 3px;
+    margin: auto;
+    border-radius: inherit;
+}
+
+.stroke {
+    width: calc(100% - 10px);
+    height: calc(100% - 10px);
+    position: absolute;
+    z-index: 1;
+    border: 3px solid var(--color-base-800);
+    top: 5px;
+    left: 5px;
+    margin: auto;
+    border-radius: inherit;
+}
+
+.actual {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: inherit;
+    background-color: var(--color-secondary-300);
+    padding: 10px 1.4rem;
+}

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/index.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/index.tsx
@@ -1,24 +1,11 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext';
 import ActualText from './ActualText';
 import Shadow from './Shadow';
 import Stroke from './Stroke';
+import styles from './highlight.module.css';
 
 function TitleHighlightedText({ children }: { readonly children: string }) {
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo((): CSSProperties => {
-        return {
-            color: theme.colors.base[900],
-            boxShadow: theme.boxShadow,
-            position: "relative",
-            rotate: "-3deg",
-            zIndex: "1",
-            borderRadius: theme.borderRadius
-        };
-    }, [theme]);
-
     return (
-        <div style={outerStyle}>
+        <div className={styles.highlight}>
             <Stroke />
             <Shadow />
             <ActualText text={children} />

--- a/react-frontend/src/components/SectionTitle/index.tsx
+++ b/react-frontend/src/components/SectionTitle/index.tsx
@@ -1,7 +1,6 @@
 import Text from '../Text'
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import TitleHighlightedText from './TitleHighlightedText';
+import styles from './SectionTitle.module.css';
 
 type SectionTitleProps = {
     readonly highlightedText?: string;
@@ -11,34 +10,11 @@ type SectionTitleProps = {
 }
 
 export default function SectionTitle({ highlightedText, text, subtitle, style }: SectionTitleProps) {
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-            ...style,
-            textAlign: "center",
-        };
-    }, [style]);
-    const titleStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "1rem",
-            fontSize: "1.2rem",
-            flexWrap: "wrap",
-        };
-    }, []);
-
     return (
-        <header style={containerStyle}>
-            <div style={titleStyle}>
+        <header className={styles.container} style={style}>
+            <div className={styles.title}>
                 {highlightedText ? <TitleHighlightedText>{highlightedText}</TitleHighlightedText> : null}
-                {text ? <Text style={{color: theme.colors.base[800]}} variant={"h2"}>{text}</Text> : null}
+                {text ? <Text variant={"h2"}><span className={styles.text}>{text}</span></Text> : null}
             </div>
             {subtitle ? <Text variant={"h3"}>{subtitle}</Text> : null}
         </header>

--- a/react-frontend/src/components/Text/index.tsx
+++ b/react-frontend/src/components/Text/index.tsx
@@ -1,45 +1,41 @@
-import { CSSProperties, ReactNode } from "react"
+import { CSSProperties, ReactNode, KeyboardEvent } from 'react';
+
+const variantTags = {
+    h1: 'h1',
+    h2: 'h2',
+    h3: 'h3',
+    h4: 'h4',
+    body: 'p',
+} as const;
 
 type TextProps = {
-    readonly variant?: keyof typeof TextVariants,
-    readonly style?: CSSProperties,
-    readonly onClick?: () => void,
-    readonly children: ReactNode,
-}
+    readonly variant?: keyof typeof variantTags;
+    readonly style?: CSSProperties;
+    readonly onClick?: () => void;
+    readonly children: ReactNode;
+};
 
-const TextVariants = {
-    h1: ({ style, onClick, children }: TextProps) =>
-        <h1 onClick={onClick}
-            onKeyDown={onClick}
-            style={style}
-            tabIndex={0}
-        >{children}</h1>,
-    h2: ({ style, onClick, children }: TextProps) =>
-        <h2 onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</h2>,
-    h3: ({ style, onClick, children }: TextProps) =>
-        <h3 onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</h3>,
-    h4: ({ style, onClick, children }: TextProps) =>
-        <h4 onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</h4>,
-    body: ({ style, onClick, children }: TextProps) =>
-        <p onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</p>,
-}
+export default function Text({ variant = 'body', style, onClick, children }: TextProps) {
+    const Tag = variantTags[variant];
 
-export default function Text({ variant = "body", style, onClick, children }: TextProps) {
-    return TextVariants[variant]({ style, onClick, children });
+    // Only expose keyboard/focus affordances when the node is actually interactive.
+    const interactiveProps = onClick
+        ? {
+              role: 'button' as const,
+              tabIndex: 0,
+              onClick,
+              onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onClick();
+                  }
+              },
+          }
+        : {};
+
+    return (
+        <Tag style={style} {...interactiveProps}>
+            {children}
+        </Tag>
+    );
 }

--- a/react-frontend/src/containers/About/About.module.css
+++ b/react-frontend/src/containers/About/About.module.css
@@ -1,0 +1,7 @@
+.container {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+}

--- a/react-frontend/src/containers/About/Content/Content.module.css
+++ b/react-frontend/src/containers/About/Content/Content.module.css
@@ -1,0 +1,11 @@
+.content {
+    font-size: 1.2rem;
+    color: var(--color-base-800);
+    text-align: left;
+}
+
+@media (max-width: 1124px) {
+    .content {
+        text-align: center;
+    }
+}

--- a/react-frontend/src/containers/About/Content/index.tsx
+++ b/react-frontend/src/containers/About/Content/index.tsx
@@ -1,24 +1,13 @@
-/** @jsxImportSource @emotion/react */
-
-import { useMediaQuery } from 'react-responsive';
-import { CSSProperties, memo, useMemo } from 'react';
+import { memo } from 'react';
 import { SanityAboutPage } from '../../../Types';
-import { useThemeContext } from '../../../contexts/ThemeContext';
 import HTMLMarkdown from '../../../components/HTMLMarkdown';
+import styles from './Content.module.css';
 
 function Content({
     description,
 }: Readonly<Omit<SanityAboutPage, 'personImage'>>) {
-    const isMediumScreen = useMediaQuery({ query: '(max-width: 1124px)' });
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => ({
-        fontSize: "1.2rem",
-        color: theme.colors.base[800],
-        textAlign: isMediumScreen ? "center" : "left",
-    }), [isMediumScreen, theme.colors.base]);
-
     return (
-        <div style={containerStyle}>
+        <div className={styles.content}>
             <HTMLMarkdown markdown={description} />
         </div>
     )

--- a/react-frontend/src/containers/About/Image/ActualImage.tsx
+++ b/react-frontend/src/containers/About/Image/ActualImage.tsx
@@ -1,32 +1,12 @@
-import { CSSProperties, useMemo } from 'react';
 import { SanityAboutPage } from '../../../Types';
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './Image.module.css';
 
 export default function ActualImage({ personImage }: Readonly<Pick<SanityAboutPage, 'personImage'>>) {
-    const { theme } = useThemeContext();
-    const imageFrameStyle = useMemo((): CSSProperties => ({
-        width: "100%",
-        height: "100%",
-        borderRadius: "50%",
-        overflow: "hidden",
-        position: "absolute",
-        boxShadow: theme.boxShadow,
-        top: "0",
-        left: "0",
-        zIndex: "2",
-        border: `3px solid ${theme.colors.base[50]}`,
-    }), [theme]);
-    const imageStyle = useMemo((): CSSProperties => ({
-        width: "100%",
-        height: "100%",
-        objectFit: "cover",
-    }), []);
-
     return (
-        <div style={imageFrameStyle}>
+        <div className={styles.imageFrame}>
             <img src={personImage}
                 alt="Shawky Ebrahim"
-                style={imageStyle} />
+                className={styles.image} />
         </div>
     )
 }

--- a/react-frontend/src/containers/About/Image/BackShape.tsx
+++ b/react-frontend/src/containers/About/Image/BackShape.tsx
@@ -1,17 +1,7 @@
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './Image.module.css';
 
 export default function BackShape() {
-    const { theme } = useThemeContext();
-
     return (
-        <div style={{
-            width: "inherit",
-            height: "inherit",
-            position: "absolute",
-            borderRadius: "50%",
-            zIndex: "1",
-            scale: "1.1",
-            border: `3px solid ${theme.colors.base[700]}`,
-        }} />
+        <div className={styles.backShape} />
     )
 }

--- a/react-frontend/src/containers/About/Image/Image.module.css
+++ b/react-frontend/src/containers/About/Image/Image.module.css
@@ -1,0 +1,35 @@
+.frame {
+    width: 320px;
+    height: 320px;
+    position: relative;
+    margin-right: 10px;
+}
+
+.backShape {
+    width: inherit;
+    height: inherit;
+    position: absolute;
+    border-radius: 50%;
+    z-index: 1;
+    scale: 1.1;
+    border: 3px solid var(--color-base-700);
+}
+
+.imageFrame {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    overflow: hidden;
+    position: absolute;
+    box-shadow: var(--shadow);
+    top: 0;
+    left: 0;
+    z-index: 2;
+    border: 3px solid var(--color-base-50);
+}
+
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}

--- a/react-frontend/src/containers/About/Image/index.tsx
+++ b/react-frontend/src/containers/About/Image/index.tsx
@@ -1,18 +1,12 @@
-import { CSSProperties, memo, useMemo } from 'react';
+import { memo } from 'react';
 import BackShape from './BackShape';
 import ActualImage from './ActualImage';
 import { SanityAboutPage } from '../../../Types';
+import styles from './Image.module.css';
 
 function Image({ personImage }: Readonly<Pick<SanityAboutPage, 'personImage'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        width: "320px",
-        height: "320px",
-        position: "relative",
-        marginRight: "10px",
-    }), []);
-
     return (
-        <div style={containerStyle}>
+        <div className={styles.frame}>
             <BackShape />
             <ActualImage personImage={personImage} />
         </div>

--- a/react-frontend/src/containers/About/index.tsx
+++ b/react-frontend/src/containers/About/index.tsx
@@ -1,38 +1,26 @@
 import ContainerWrap from '../../components/ContainerWrap'
 import Content from './Content';
 import Image from './Image';
-import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { SanityAboutPage } from '../../Types';
 import { getAboutPage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from './About.module.css';
 
 function About() {
-    const [aboutPage, setAboutPage] = useState<SanityAboutPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column-reverse",
-        justifyContent: "space-between",
-        alignItems: "center",
-        gap: "2rem",
-    }), []);
+    const { data: aboutPage, error } = useSanityQuery<SanityAboutPage>(getAboutPage);
 
-    useEffect(() => {
-        getAboutPage().then((result) => {
-            setAboutPage(result);
-        });
-    }, []);
+    if (error) return <SectionError />;
+    if (!aboutPage) return <Loader />;
 
     return (
-        <>
-            {aboutPage ? (
-                <div style={containerStyle}>
-                    <Content
-                        description={aboutPage.description}
-                    />
-                    <Image personImage={aboutPage.personImage} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.container}>
+            <Content
+                description={aboutPage.description}
+            />
+            <Image personImage={aboutPage.personImage} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Contacts/Content.module.css
+++ b/react-frontend/src/containers/Contacts/Content.module.css
@@ -1,0 +1,7 @@
+.contacts {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/containers/Contacts/Content.tsx
+++ b/react-frontend/src/containers/Contacts/Content.tsx
@@ -1,16 +1,11 @@
 import { memo } from "react";
 import { SanityContactsPage } from "../../Types";
 import Icon from "../../components/Icon";
+import styles from "./Content.module.css";
 
 function Content({ contacts }: Readonly<Pick<SanityContactsPage, "contacts">>) {
     return (
-        <div style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "2rem",
-            flexWrap: "wrap",
-        }}>
+        <div className={styles.contacts}>
             {contacts.map((contact) => {
                 return (
                     <Icon

--- a/react-frontend/src/containers/Contacts/index.tsx
+++ b/react-frontend/src/containers/Contacts/index.tsx
@@ -1,36 +1,24 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
 import ContainerWrap from '../../components/ContainerWrap';
 import { getContactsPage } from '../../APIs';
 import { SanityContactsPage } from '../../Types';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Content from './Content';
 import Title from '../Title';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Contacts() {
-    const [contactsPage, setContactsPage] = useState<SanityContactsPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: contactsPage, error } = useSanityQuery<SanityContactsPage>(getContactsPage);
 
-    useEffect(() => {
-        getContactsPage().then((result) => {
-            setContactsPage(result);
-        })
-    }, []);
+    if (error) return <SectionError />;
+    if (!contactsPage) return <Loader />;
 
     return (
-        <>
-            {contactsPage ? (
-                <div style={containerStyle}>
-                    <Title title={contactsPage.title} />
-                    <Content contacts={contactsPage.contacts} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={contactsPage.title} />
+            <Content contacts={contactsPage.contacts} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Education/Content/CoursesItems.tsx
+++ b/react-frontend/src/containers/Education/Content/CoursesItems.tsx
@@ -1,23 +1,18 @@
 import ListButtons from '../../../components/ListButtons'
-import { CSSProperties, memo, useMemo } from 'react';
+import { memo } from 'react';
 import { SanityEducationPage } from '../../../Types';
 import HTMLMarkdown from '../../../components/HTMLMarkdown';
 import MainSection from '../../../components/MainSection';
+import surfaces from '../../../styles/surfaces.module.css';
 
 function CoursesItems({ courses }: Readonly<Pick<SanityEducationPage["education"], "courses">>) {
-    const innerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {courses.map((course, index) => {
                 return (
                     <MainSection
                         key={course.description}>
-                        <div style={innerStyle}>
+                        <div className={surfaces.stack}>
                             <HTMLMarkdown markdown={course.description} />
                             {course.technologies && <ListButtons elements={course.technologies} />}
                         </div>

--- a/react-frontend/src/containers/Education/Content/index.tsx
+++ b/react-frontend/src/containers/Education/Content/index.tsx
@@ -1,21 +1,15 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { memo } from "react";
 import { SanityEducationPage } from "../../../Types";
 import MainSection from "../../../components/MainSection";
 import CoursesItems from "./CoursesItems";
 import HTMLMarkdown from "../../../components/HTMLMarkdown";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ education }: Readonly<Pick<SanityEducationPage, "education">>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <MainSection
             subtitle={education.description}>
-            <div style={containerStyle}>
+            <div className={surfaces.stack}>
                 <div>
                     <HTMLMarkdown markdown={education.description} />
                 </div>

--- a/react-frontend/src/containers/Education/index.tsx
+++ b/react-frontend/src/containers/Education/index.tsx
@@ -1,36 +1,24 @@
 import ContainerWrap from '../../components/ContainerWrap'
-import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { SanityEducationPage } from '../../Types';
 import { getEducationPage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Title from '../Title';
 import Content from './Content';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Education() {
-    const [educationPage, setEducationPage] = useState<SanityEducationPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: educationPage, error } = useSanityQuery<SanityEducationPage>(getEducationPage);
 
-    useEffect(() => {
-        getEducationPage().then((result) => {
-            setEducationPage(result);
-        });
-    }, []);
+    if (error) return <SectionError />;
+    if (!educationPage) return <Loader />;
 
     return (
-        <>
-            {educationPage ? (
-                <div style={containerStyle}>
-                    <Title title={educationPage.title} />
-                    <Content education={educationPage.education} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={educationPage.title} />
+            <Content education={educationPage.education} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Experience/Certificates/Content.tsx
+++ b/react-frontend/src/containers/Experience/Certificates/Content.tsx
@@ -1,20 +1,13 @@
-import { CSSProperties, useMemo } from "react";
 import { SanityExperiencePage } from "../../../Types";
 import ExperienceItemDescription from "../ExperienceItemDescription";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ certificates }: Readonly<Pick<SanityExperiencePage['certificatesSection'], 'certificates'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {certificates.map((certificate) => {
                 return (
-                    <div style={containerStyle} key={certificate.description}>
+                    <div className={surfaces.stack} key={certificate.description}>
                         {certificate.description && <ExperienceItemDescription description={certificate.description} />}
                     </div>
                 )

--- a/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.module.css
+++ b/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.module.css
@@ -1,0 +1,7 @@
+.group {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    width: fit-content;
+    gap: 0.5rem;
+}

--- a/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.tsx
+++ b/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.tsx
@@ -1,5 +1,5 @@
 import Text from '../../../components/Text'
-import { CSSProperties, useMemo } from 'react'
+import styles from './SubtitleAndDate.module.css'
 
 type SubtitleAndDateProps = {
     readonly subTitle: string,
@@ -7,16 +7,8 @@ type SubtitleAndDateProps = {
 }
 
 export default function SubtitleAndDate({ subTitle, date }: SubtitleAndDateProps) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        alignItems: "flex-start",
-        flexDirection: "column",
-        width: "fit-content",
-        gap: "0.5rem",
-    }), []);
-
     return (
-        <div style={containerStyle}>
+        <div className={styles.group}>
             <Text variant={"h4"}>
                 {subTitle}
             </Text>

--- a/react-frontend/src/containers/Experience/Internships/Content.tsx
+++ b/react-frontend/src/containers/Experience/Internships/Content.tsx
@@ -1,20 +1,13 @@
-import { CSSProperties, useMemo } from "react";
 import { SanityExperiencePage } from "../../../Types";
 import ExperienceItemDescription from "../ExperienceItemDescription";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ internships }: Readonly<Pick<SanityExperiencePage['internshipsSection'], 'internships'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {internships.map((internship) => {
                 return (
-                    <div style={containerStyle} key={internship.description}>
+                    <div className={surfaces.stack} key={internship.description}>
                         <ExperienceItemDescription description={internship.description} />
                     </div>
                 )

--- a/react-frontend/src/containers/Experience/ProfessionalExperience/Content.tsx
+++ b/react-frontend/src/containers/Experience/ProfessionalExperience/Content.tsx
@@ -1,20 +1,13 @@
-import { CSSProperties, useMemo } from "react";
 import { SanityExperiencePage } from "../../../Types";
 import ExperienceItemDescription from "../ExperienceItemDescription";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ professionalExperience }: Readonly<Pick<SanityExperiencePage['professionalExperienceSection'], 'professionalExperience'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {professionalExperience.map((experience) => {
                 return (
-                    <div style={containerStyle} key={experience.description}>
+                    <div className={surfaces.stack} key={experience.description}>
                         <ExperienceItemDescription description={experience.description} />
                     </div>
                 )

--- a/react-frontend/src/containers/Experience/index.tsx
+++ b/react-frontend/src/containers/Experience/index.tsx
@@ -1,38 +1,26 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
 import ContainerWrap from '../../components/ContainerWrap'
 import { SanityExperiencePage } from '../../Types';
 import Certificates from './Certificates';
 import { getExperiencePage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Internships from './Internships';
 import ProfessionalExperience from './ProfessionalExperience';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Experience() {
-    const [experiences, setExperiences] = useState<SanityExperiencePage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: experiences, error } = useSanityQuery<SanityExperiencePage>(getExperiencePage);
 
-    useEffect(() => {
-        getExperiencePage().then((result) => {
-            setExperiences(result);
-        });
-    }, []);
+    if (error) return <SectionError />;
+    if (!experiences) return <Loader />;
 
     return (
-        <>
-            {experiences ? (
-                <div style={containerStyle}>
-                    <ProfessionalExperience professionalExperienceSection={experiences.professionalExperienceSection} />
-                    <Internships internshipsSection={experiences.internshipsSection} />
-                    <Certificates certificatesSection={experiences.certificatesSection} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <ProfessionalExperience professionalExperienceSection={experiences.professionalExperienceSection} />
+            <Internships internshipsSection={experiences.internshipsSection} />
+            <Certificates certificatesSection={experiences.certificatesSection} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/MarkdownEditor/MarkdownEditor.module.css
+++ b/react-frontend/src/containers/MarkdownEditor/MarkdownEditor.module.css
@@ -1,0 +1,25 @@
+.editor {
+    display: grid;
+}
+
+.textarea {
+    flex: 1;
+    min-height: 150px;
+    padding: 15px;
+    font-size: 16px;
+    resize: vertical;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    outline: none;
+    font-family: Arial, sans-serif;
+    line-height: 1.5;
+    margin-bottom: 20px;
+    transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.preview {
+    flex: 1;
+    padding: 10px;
+    border-top: var(--border);
+}

--- a/react-frontend/src/containers/MarkdownEditor/index.tsx
+++ b/react-frontend/src/containers/MarkdownEditor/index.tsx
@@ -1,6 +1,7 @@
-import React, { CSSProperties, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import HTMLMarkdown from '../../components/HTMLMarkdown';
 import ContainerWrap from '../../components/ContainerWrap';
+import styles from './MarkdownEditor.module.css';
 
 const MarkdownEditor = () => {
     const [markdown, setMarkdown] = useState<string>('');
@@ -9,31 +10,15 @@ const MarkdownEditor = () => {
         setMarkdown(event.target.value);
     };
 
-    const textAreaStyle = useMemo((): CSSProperties => ({
-        flex: 1,
-        minHeight: '150px',
-        padding: '15px',
-        fontSize: '16px',
-        resize: 'vertical',
-        border: '1px solid #ccc',
-        borderRadius: '8px',
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-        outline: 'none',
-        fontFamily: 'Arial, sans-serif',
-        lineHeight: '1.5',
-        marginBottom: '20px',
-        transition: 'border-color 0.3s, box-shadow 0.3s',
-    }), []);
-
     return (
-        <div style={{ display: 'grid' }}>
+        <div className={styles.editor}>
             <textarea
-                style={textAreaStyle}
+                className={styles.textarea}
                 value={markdown}
                 onChange={handleMarkdownChange}
                 placeholder="Write your Markdown here..."
             />
-            <div style={{ flex: 1, padding: '10px', borderTop: '1px solid #ccc' }}>
+            <div className={styles.preview}>
                 <HTMLMarkdown markdown={markdown} />
             </div>
         </div>

--- a/react-frontend/src/containers/Projects/index.tsx
+++ b/react-frontend/src/containers/Projects/index.tsx
@@ -1,36 +1,24 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
-import ContainerWrap from '../../components/ContainerWrap';
+import ContainerWrap from '../../components/ContainerWrap'
 import { SanityProjectsPage } from '../../Types';
 import { getProjectsPage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Title from '../Title';
 import Content from './Content';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Projects() {
-    const [projects, setProjects] = useState<SanityProjectsPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: projects, error } = useSanityQuery<SanityProjectsPage>(getProjectsPage);
 
-    useEffect(() => {
-        getProjectsPage().then((result) => {
-            setProjects(result);
-        })
-    }, []);
+    if (error) return <SectionError />;
+    if (!projects) return <Loader />;
 
     return (
-        <>
-            {projects ? (
-                <div style={containerStyle}>
-                    <Title title={projects.title} />
-                    <Content projects={projects.projects} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={projects.title} />
+            <Content projects={projects.projects} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Skills/Content/Content.module.css
+++ b/react-frontend/src/containers/Skills/Content/Content.module.css
@@ -1,0 +1,7 @@
+.list {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/containers/Skills/Content/index.tsx
+++ b/react-frontend/src/containers/Skills/Content/index.tsx
@@ -1,19 +1,11 @@
-import { CSSProperties, useMemo } from 'react';
 import { SanitySkillsPage } from '../../../Types';
 import CenteredSection from '../../../components/CenteredSection';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from '@fortawesome/free-solid-svg-icons';
 import SkillsIcons from './SkillsIcons';
+import styles from './Content.module.css';
 
 export default function Content({ categories }: Readonly<Pick<SanitySkillsPage, "categories">>) {
-    const listItemsContainerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "1rem",
-        flexWrap: "wrap",
-    }), []);
-
     return (
         <>
             {categories.map((category) => {
@@ -22,7 +14,7 @@ export default function Content({ categories }: Readonly<Pick<SanitySkillsPage, 
                         key={category.title}
                         icon={<HeaderIcon />}
                         title={category.title} >
-                        <div style={listItemsContainerStyle}>
+                        <div className={styles.list}>
                             <SkillsIcons skills={category.skills} />
                         </div>
                     </CenteredSection>

--- a/react-frontend/src/containers/Skills/index.tsx
+++ b/react-frontend/src/containers/Skills/index.tsx
@@ -1,36 +1,24 @@
 import ContainerWrap from '../../components/ContainerWrap'
 import Content from './Content';
-import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { SanitySkillsPage } from '../../Types';
 import { getSkillsPage } from '../../APIs';
 import Title from '../Title';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Skills() {
-    const [skillsPage, setSkillsPage] = useState<SanitySkillsPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: skillsPage, error } = useSanityQuery<SanitySkillsPage>(getSkillsPage);
 
-    useEffect(() => {
-        getSkillsPage().then((result) => {
-            setSkillsPage(result)
-        })
-    }, [])
+    if (error) return <SectionError />;
+    if (!skillsPage) return <Loader />;
 
     return (
-        <>
-            {skillsPage ? (
-                <div style={containerStyle}>
-                    <Title title={skillsPage.title} />
-                    <Content categories={skillsPage.categories} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={skillsPage.title} />
+            <Content categories={skillsPage.categories} />
+        </div>
     )
 }
 

--- a/react-frontend/src/contexts/ThemeContext.tsx
+++ b/react-frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 import backgroundImage from '../assets/background.svg';
-import { Theme } from '../Types';
+import { ColorLevels, Theme } from '../Types';
 
 type ThemeContextType = {
     theme: Theme,
@@ -9,52 +9,33 @@ type ThemeContextType = {
 
 const Context = createContext<ThemeContextType | null>(null);
 
-// Colors generate from: https://accessiblepalette.com/?lightness=98.2,93.95,85.1,76.5,67.65,57,47,40.4,24,16&5DACC9=1,0&f2f3ea=1,0
+// Token values live in src/styles/tokens.css. The theme references them as
+// CSS custom properties so JS-driven styles and *.module.css stay in sync.
+
+const colorRamp = (name: "base" | "secondary"): ColorLevels =>
+    ([0, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const).reduce(
+        (ramp, level) => ({ ...ramp, [level]: `var(--color-${name}-${level})` }),
+        {} as ColorLevels
+    );
 
 const colors = {
-    base: {
-        0: "#FFFFFF",
-        50: "#FAFAF6",
-        100: "#EDEEE6",
-        200: "#D4D5CD",
-        300: "#BDBDB6",
-        400: "#A5A59F",
-        500: "#898984",
-        600: "#6F706C",
-        700: "#545451",
-        800: "#393937",
-        900: "#282827",
-    },
-    secondary: {
-        0: "#FFFFFF",
-        50: "#FEF9F5",
-        100: "#FBEBDD",
-        200: "#F8D7BC",
-        300: "#F6C29A",
-        400: "#D4986C",
-        500: "#B4805B",
-        600: "#93684B",
-        700: "#7C573F",
-        800: "#644633",
-        900: "#4A3326",
-    },
-    opacity: (percentage: number) => `rgba(255,255,255,${percentage})`,
+    base: colorRamp("base"),
+    secondary: colorRamp("secondary"),
+    opacity: (percentage: number): string => `rgba(255,255,255,${percentage})`,
 }
 
 const themeProperties: Theme = {
     colors,
-    transition: "all 0.3s ease-out",
-    borderRadius: "8px",
-    boxShadow: "rgba(0, 0, 0, 0.24) 0px 3px 8px",
+    transition: "var(--transition)",
+    borderRadius: "var(--radius)",
+    boxShadow: "var(--shadow)",
     backgroundImage: `url(${backgroundImage})`,
-    border: '',
+    border: "var(--border)",
     boxingStyle: {},
     button: {},
     container: {},
     buttonEffects: {},
 };
-
-themeProperties.border = `1px solid ${themeProperties.colors.base[50]}`;
 
 themeProperties.boxingStyle = {
     border: themeProperties.border,

--- a/react-frontend/src/hooks/useSanityQuery.ts
+++ b/react-frontend/src/hooks/useSanityQuery.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+type QueryState<T> = {
+    data: T | null;
+    loading: boolean;
+    error: Error | null;
+};
+
+/**
+ * Fetches data from a Sanity query function with loading/error state.
+ *
+ * Replaces the repeated useState(null) + useEffect(fetch) pattern across
+ * containers and, crucially, adds the error handling those copies lacked
+ * (a rejected fetch previously left the loader spinning forever).
+ *
+ * Pass a stable `queryFn` reference (e.g. an imported API function).
+ */
+export function useSanityQuery<T>(queryFn: () => Promise<T>): QueryState<T> {
+    const [state, setState] = useState<QueryState<T>>({
+        data: null,
+        loading: true,
+        error: null,
+    });
+
+    useEffect(() => {
+        let active = true;
+        setState({ data: null, loading: true, error: null });
+
+        queryFn()
+            .then((data) => {
+                if (active) {
+                    setState({ data, loading: false, error: null });
+                }
+            })
+            .catch((error: unknown) => {
+                if (active) {
+                    setState({
+                        data: null,
+                        loading: false,
+                        error: error instanceof Error ? error : new Error(String(error)),
+                    });
+                }
+            });
+
+        return () => {
+            active = false;
+        };
+    }, [queryFn]);
+
+    return state;
+}

--- a/react-frontend/src/index.tsx
+++ b/react-frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './styles/tokens.css';
 import './index.css';
 import App from './App';
 import { Analytics } from '@vercel/analytics/react';

--- a/react-frontend/src/react-app-env.d.ts
+++ b/react-frontend/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/react-frontend/src/styles/section.module.css
+++ b/react-frontend/src/styles/section.module.css
@@ -1,0 +1,7 @@
+.section {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 2rem;
+}

--- a/react-frontend/src/styles/surfaces.module.css
+++ b/react-frontend/src/styles/surfaces.module.css
@@ -1,0 +1,26 @@
+/* Shared surface treatments — replaces theme.container / theme.boxingStyle. */
+
+.container {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem;
+    place-items: stretch;
+    background-color: var(--color-base-50);
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.boxing {
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.column {
+    flex-direction: column;
+}
+
+.center {
+    text-align: center;
+}

--- a/react-frontend/src/styles/surfaces.module.css
+++ b/react-frontend/src/styles/surfaces.module.css
@@ -24,3 +24,11 @@
 .center {
     text-align: center;
 }
+
+/* Vertical stack used by container content groups (Education, Experience). */
+.stack {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+}

--- a/react-frontend/src/styles/tokens.css
+++ b/react-frontend/src/styles/tokens.css
@@ -1,0 +1,59 @@
+/**
+ * Design tokens — single source of truth for the portfolio's visual language.
+ *
+ * These CSS custom properties are consumed two ways:
+ *   1. Directly in *.module.css files via var(--token).
+ *   2. Through the TS theme (contexts/ThemeContext), which exposes the same
+ *      tokens as var() references so existing inline/emotion styles keep working.
+ *
+ * Color ramps generated from:
+ * https://accessiblepalette.com/?lightness=98.2,93.95,85.1,76.5,67.65,57,47,40.4,24,16
+ */
+
+:root {
+  /* Base (neutral) ramp */
+  --color-base-0: #ffffff;
+  --color-base-50: #fafaf6;
+  --color-base-100: #edeee6;
+  --color-base-200: #d4d5cd;
+  --color-base-300: #bdbdb6;
+  --color-base-400: #a5a59f;
+  --color-base-500: #898984;
+  --color-base-600: #6f706c;
+  --color-base-700: #545451;
+  --color-base-800: #393937;
+  --color-base-900: #282827;
+
+  /* Secondary (warm) ramp */
+  --color-secondary-0: #ffffff;
+  --color-secondary-50: #fef9f5;
+  --color-secondary-100: #fbebdd;
+  --color-secondary-200: #f8d7bc;
+  --color-secondary-300: #f6c29a;
+  --color-secondary-400: #d4986c;
+  --color-secondary-500: #b4805b;
+  --color-secondary-600: #93684b;
+  --color-secondary-700: #7c573f;
+  --color-secondary-800: #644633;
+  --color-secondary-900: #4a3326;
+
+  /* Radius */
+  --radius: 8px;
+
+  /* Elevation */
+  --shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+
+  /* Motion */
+  --transition: all 0.3s ease-out;
+
+  /* Borders */
+  --border: 1px solid var(--color-base-50);
+
+  /* Spacing scale (used by layout primitives and components) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
+  --space-6: 3rem;
+}

--- a/react-frontend/src/utils/cx.ts
+++ b/react-frontend/src/utils/cx.ts
@@ -1,0 +1,7 @@
+/**
+ * Minimal classnames helper — joins truthy class strings.
+ * Usage: cx(styles.icon, size === 'lg' && styles.lg, pointer && styles.pointer)
+ */
+export function cx(...classes: Array<string | false | null | undefined>): string {
+    return classes.filter(Boolean).join(' ');
+}

--- a/react-frontend/src/vite-env.d.ts
+++ b/react-frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/react-frontend/tsconfig.json
+++ b/react-frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Design/styling refactor — multi-phase

Centralizes the react-frontend styling architecture: eliminates inline `style={{}}` sprawl in favor of **CSS Modules + CSS variables**, plus code-quality and tooling improvements. Work lands incrementally per phase on this branch.

### Phase 0 — Foundation ✅ (this commit)
- **`src/styles/tokens.css`**: single source of truth for design tokens (color ramps, radius, shadow, transition, border, spacing) as CSS custom properties.
- **`ThemeContext`** now references `var(--token)` instead of hard-coded hex — *zero visual change*, but tokens flow from one place. Removed the post-construction mutation of `border`.
- **Type safety**: `Theme` composite styles `object` → `CSSObject`/`CSSProperties`; fixed `opacity` return type (`void` → `string`).
- **Tooling**: replaced CRA `react-app-env.d.ts` with Vite `vite-env.d.ts` (fixes the long-standing `*.svg` tsc error); bumped `tsconfig` target `es5` → `ES2020`; added **ESLint 9 flat config + Prettier** with `lint`/`format` scripts.

`tsc --noEmit` clean, `npm run build` green.

### Upcoming
- **Phase 1** — convert shared primitives (Button/Text/Icon/SectionTitle/CenteredSection/ContainerWrap) to `.module.css`; add layout primitives; fix Text-as-JSX + button/a11y semantics.
- **Phase 2** — convert all containers' inline styles to CSS Modules.
- **Phase 3** — `useSanityQuery` hook with error handling; move Sanity config to `VITE_SANITY_*` env; guard the markdown test route from production.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>