### PR TITLE
release: promote Development to main — clears 13 Dependabot alerts

### DIFF
--- a/react-frontend/.env.example
+++ b/react-frontend/.env.example
@@ -1,0 +1,5 @@
+# Sanity content source (public project values; safe to expose in the client).
+# Copy to .env.local to override. All VITE_* vars are bundled into the client.
+VITE_SANITY_PROJECT_ID=h48br789
+VITE_SANITY_DATASET=production
+VITE_SANITY_API_VERSION=2022-03-07

--- a/react-frontend/.prettierignore
+++ b/react-frontend/.prettierignore
@@ -1,0 +1,6 @@
+build
+dist
+node_modules
+coverage
+package-lock.json
+*.svg

--- a/react-frontend/.prettierrc.json
+++ b/react-frontend/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "printWidth": 100
+}

--- a/react-frontend/eslint.config.mjs
+++ b/react-frontend/eslint.config.mjs
@@ -1,0 +1,38 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+    {
+        ignores: ['build', 'dist', 'node_modules', 'coverage'],
+    },
+    {
+        files: ['**/*.{ts,tsx}'],
+        extends: [
+            js.configs.recommended,
+            ...tseslint.configs.recommended,
+            reactHooks.configs['recommended-latest'],
+        ],
+        languageOptions: {
+            ecmaVersion: 2020,
+            globals: globals.browser,
+        },
+        plugins: {
+            'react-refresh': reactRefresh,
+        },
+        rules: {
+            'react-refresh/only-export-components': [
+                'warn',
+                { allowConstantExport: true },
+            ],
+            '@typescript-eslint/no-unused-vars': [
+                'warn',
+                { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+            ],
+        },
+    },
+    prettier
+);

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -17,28 +17,36 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/jest": "^29.5.14",
-        "@types/node": "^26.0.1",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^26.1.0",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vercel/analytics": "^1.3.2",
+        "@vercel/analytics": "^2.0.1",
         "hast-util-to-jsx-runtime": "^2.3.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-markdown": "^9.0.1",
+        "react-markdown": "^10.1.0",
         "react-responsive": "^10.0.1",
         "react-router-dom": "^7.18.1",
         "rehype-stringify": "^10.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "unist-util-visit": "^5.1.0",
-        "uuid": "^11.0.2",
-        "web-vitals": "^4.2.4"
+        "uuid": "^14.0.1",
+        "web-vitals": "^5.3.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@vitejs/plugin-react": "^6.0.3",
+        "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.7.0",
         "jsdom": "^29.1.1",
-        "typescript": "5.6.3",
+        "prettier": "^3.9.4",
+        "typescript": "6.0.3",
+        "typescript-eslint": "^8.62.1",
         "vite": "^8.1.0",
         "vitest": "^4.1.9"
       }
@@ -540,6 +548,163 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -604,45 +769,143 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "license": "MIT",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "jest-get-type": "^29.6.3"
+        "@humanfs/types": "^0.15.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1092,9 +1355,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -1295,13 +1558,13 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
       "license": "MIT",
       "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
       }
     },
     "node_modules/@types/jest/node_modules/ansi-styles": {
@@ -1317,23 +1580,25 @@
       }
     },
     "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -1352,9 +1617,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1411,6 +1676,288 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
@@ -1418,14 +1965,15 @@
       "license": "ISC"
     },
     "node_modules/@vercel/analytics": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
-      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
-      "license": "MPL-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
       "peerDependencies": {
         "@remix-run/react": "^2",
         "@sveltejs/kit": "^1 || ^2",
         "next": ">= 13",
+        "nuxt": ">= 3",
         "react": "^18 || ^19 || ^19.0.0-rc",
         "svelte": ">= 4",
         "vue": "^3",
@@ -1439,6 +1987,9 @@
           "optional": true
         },
         "next": {
+          "optional": true
+        },
+        "nuxt": {
           "optional": true
         },
         "react": {
@@ -1601,6 +2152,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1625,6 +2216,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -1670,6 +2268,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1680,16 +2285,15 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/callsites": {
@@ -1778,9 +2382,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "funding": [
         {
           "type": "github",
@@ -1819,6 +2423,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
@@ -1862,6 +2473,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-mediaquery": {
@@ -1962,6 +2588,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1992,15 +2625,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -2060,6 +2684,189 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -2080,6 +2887,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/event-source-polyfill": {
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
@@ -2096,19 +2913,20 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -2127,16 +2945,38 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "to-regex-range": "^5.0.1"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/find-root": {
@@ -2144,6 +2984,44 @@
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2182,6 +3060,32 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -2322,6 +3226,16 @@
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2336,6 +3250,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -2414,6 +3338,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -2422,15 +3369,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2464,19 +3402,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
@@ -2492,47 +3437,33 @@
       }
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
@@ -2548,43 +3479,39 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-matcher-utils/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
     "node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
@@ -2600,40 +3527,58 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-message-util/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "jest-util": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -2641,6 +3586,29 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -2695,11 +3663,56 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2978,6 +3991,29 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -3917,19 +4953,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -3949,6 +4972,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -3975,6 +5011,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3996,6 +5039,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parent-module": {
@@ -4066,6 +5159,26 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4095,12 +5208,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -4133,6 +5246,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -4228,10 +5367,24 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
+    },
     "node_modules/react-markdown": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
-      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4556,6 +5709,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -4567,6 +5733,29 @@
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
       "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4681,6 +5870,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/style-to-js": {
@@ -4799,19 +6001,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -4841,18 +6030,6 @@
       "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
@@ -4900,6 +6077,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4918,10 +6108,23 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4930,6 +6133,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {
@@ -5035,6 +6262,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5042,16 +6279,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -5160,19 +6397,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
@@ -5263,19 +6487,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -5290,9 +6501,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
@@ -5330,6 +6541,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5345,6 +6572,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/xml-name-validator": {
@@ -5364,20 +6601,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 14.6"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/eemeli"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zwitch": {

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -12,29 +12,32 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/jest": "^29.5.14",
-    "@types/node": "^26.0.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^26.1.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "@vercel/analytics": "^1.3.2",
+    "@vercel/analytics": "^2.0.1",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^10.1.0",
     "react-responsive": "^10.0.1",
     "react-router-dom": "^7.18.1",
     "rehype-stringify": "^10.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "unist-util-visit": "^5.1.0",
-    "uuid": "^11.0.2",
-    "web-vitals": "^4.2.4"
+    "uuid": "^14.0.1",
+    "web-vitals": "^5.3.0"
   },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "lint": "eslint .",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\""
   },
   "browserslist": {
     "production": [
@@ -49,13 +52,21 @@
     ]
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@vitejs/plugin-react": "^6.0.3",
+    "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.5.3",
+    "globals": "^17.7.0",
     "jsdom": "^29.1.1",
-    "typescript": "5.6.3",
+    "prettier": "^3.9.4",
+    "typescript": "6.0.3",
+    "typescript-eslint": "^8.62.1",
     "vite": "^8.1.0",
     "vitest": "^4.1.9"
   },
   "overrides": {
-    "typescript": "5.6.3"
+    "typescript": "6.0.3"
   }
 }

--- a/react-frontend/src/APIs/Sanity/client.ts
+++ b/react-frontend/src/APIs/Sanity/client.ts
@@ -1,10 +1,12 @@
 import { createClient } from '@sanity/client'
 
+// Config is sourced from Vite env vars, falling back to the public project
+// defaults so the app keeps working without a local .env. See .env.example.
 const sanityClient = createClient({
-    projectId: 'h48br789',
-    dataset: 'production',
+    projectId: import.meta.env.VITE_SANITY_PROJECT_ID ?? 'h48br789',
+    dataset: import.meta.env.VITE_SANITY_DATASET ?? 'production',
+    apiVersion: import.meta.env.VITE_SANITY_API_VERSION ?? '2022-03-07',
     useCdn: true,
-    apiVersion: '2022-03-07',
 })
 
 export default sanityClient;

--- a/react-frontend/src/Portfolio/Portfolio.module.css
+++ b/react-frontend/src/Portfolio/Portfolio.module.css
@@ -1,0 +1,20 @@
+.page {
+    background-color: var(--color-base-100);
+    min-height: 100vh;
+    color: var(--color-base-700);
+    background-image: var(--portfolio-bg);
+    background-size: auto;
+    background-repeat: repeat;
+    background-position: center;
+}
+
+.page *::selection {
+    background-color: var(--color-base-700);
+    color: var(--color-base-100);
+}
+
+.inner {
+    max-width: 1255px;
+    margin: 0 auto;
+    padding: 0 1rem;
+}

--- a/react-frontend/src/Portfolio/index.tsx
+++ b/react-frontend/src/Portfolio/index.tsx
@@ -1,9 +1,6 @@
-/** @jsxImportSource @emotion/react */
-
-import { useThemeContext } from '../contexts/ThemeContext';
 import Navbar from '../components/Navbar';
 import Contacts from '../containers/Contacts';
-import { Suspense, lazy } from 'react';
+import { CSSProperties, Suspense, lazy } from 'react';
 import Loader from '../components/Loader';
 import {
     BrowserRouter,
@@ -11,57 +8,37 @@ import {
     Routes,
 } from "react-router-dom";
 import { PortfolioPathes } from '../Types';
-import { css } from '@emotion/react';
-import MarkdownEditor from '../containers/MarkdownEditor';
+import backgroundImage from '../assets/background.svg';
+import styles from './Portfolio.module.css';
 
 const About = lazy(() => import('../containers/About'));
 const Skills = lazy(() => import('../containers/Skills'));
 const Education = lazy(() => import('../containers/Education'));
 const Experience = lazy(() => import('../containers/Experience'));
 const Projects = lazy(() => import('../containers/Projects'));
+const MarkdownEditor = lazy(() => import('../containers/MarkdownEditor'));
 
 type PathElementRoutes = Record<PortfolioPathes, React.JSX.Element>
-type TestingRoutes = {
-    "markdown": React.JSX.Element
-}
 
-const pathElementRoutes: PathElementRoutes & TestingRoutes = {
+const pathElementRoutes: PathElementRoutes = {
     "": <About />,
     "skills": <Skills />,
     "education": <Education />,
     "experience": <Experience />,
     "projects": <Projects />,
     "contacts": <Contacts />,
-    "markdown": <MarkdownEditor />
 }
 
 export default function Portfolio() {
-    const { theme } = useThemeContext();
-
     return (
-        <div css={css({
-            backgroundColor: theme.colors.base[100],
-            minHeight: "100vh",
-            color: theme.colors.base[700],
-            backgroundImage: theme.backgroundImage,
-            backgroundSize: 'auto', // Adjust the size of the background image
-            backgroundRepeat: 'repeat', // Repeat the background image
-            backgroundPosition: 'center',
-            '& *::selection': {
-                backgroundColor: theme.colors.base[700],
-                color: theme.colors.base[100]
-            }
-        })}>
-            <div style={{
-                maxWidth: "1255px",
-                margin: "0 auto",
-                padding: "0 1rem",
-            }}>
+        <div
+            className={styles.page}
+            style={{ '--portfolio-bg': `url(${backgroundImage})` } as CSSProperties}>
+            <div className={styles.inner}>
                 <Suspense fallback={<Loader />}>
                     <BrowserRouter>
                         <Navbar />
                         <Routes>
-                            <Route path='/' element={<About />} />
                             {Object.entries(pathElementRoutes).map(([path, element]) => {
                                 return (
                                     <Route
@@ -70,6 +47,10 @@ export default function Portfolio() {
                                         element={element} />
                                 )
                             })}
+                            {/* Markdown editor is a dev-only authoring tool, not shipped in production routing. */}
+                            {import.meta.env.DEV && (
+                                <Route path="/markdown" element={<MarkdownEditor />} />
+                            )}
                         </Routes>
                     </BrowserRouter>
                 </Suspense>

--- a/react-frontend/src/Types/contexts.ts
+++ b/react-frontend/src/Types/contexts.ts
@@ -1,3 +1,6 @@
+import { CSSObject } from '@emotion/react';
+import { CSSProperties } from 'react';
+
 type ColorLevels = {
     0: string,
     50: string,
@@ -16,19 +19,19 @@ type Theme = {
     colors: {
         base: ColorLevels,
         secondary: ColorLevels,
-        opacity: (percentage: number) => void
+        opacity: (percentage: number) => string
     },
     transition: string,
     borderRadius: string,
     boxShadow: string,
     backgroundImage: string,
     border: string,
-    button: object,
-    boxingStyle: object,
-    container: object,
-    buttonEffects: object,
+    button: CSSObject,
+    boxingStyle: CSSProperties,
+    container: CSSProperties,
+    buttonEffects: CSSObject,
 };
 
 type PortfolioPathes = "" | "skills" | "education" | "experience" | "projects" | "contacts";
 
-export { type Theme, type PortfolioPathes }
+export { type Theme, type PortfolioPathes, type ColorLevels }

--- a/react-frontend/src/Types/index.ts
+++ b/react-frontend/src/Types/index.ts
@@ -9,4 +9,4 @@ export {
     type SanityNavbarData
 } from './sanity';
 
-export { type Theme, type PortfolioPathes } from './contexts';
+export { type Theme, type PortfolioPathes, type ColorLevels } from './contexts';

--- a/react-frontend/src/components/BlurBackground.module.css
+++ b/react-frontend/src/components/BlurBackground.module.css
@@ -1,0 +1,9 @@
+.blur {
+    z-index: -1;
+    position: absolute;
+    backdrop-filter: blur(8px);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/react-frontend/src/components/BlurBackground.tsx
+++ b/react-frontend/src/components/BlurBackground.tsx
@@ -1,4 +1,4 @@
-/** @jsxImportSource @emotion/react */
+import styles from './BlurBackground.module.css';
 
 type BlurBackgroundProps = {
     backgroundColor: string,
@@ -6,19 +6,8 @@ type BlurBackgroundProps = {
 
 export default function BlurBackground({ backgroundColor }: BlurBackgroundProps) {
     return (
-        <div css={{
-            zIndex: -1,
-            position: "absolute",
-            backgroundColor: toRGBA(backgroundColor, 0.8),
-            backdropFilter: "blur(8px)",
-            top: "0",
-            left: "0",
-            width: "100%",
-            height: "100%",
-        }} />
+        <div
+            className={styles.blur}
+            style={{ backgroundColor: `color-mix(in srgb, ${backgroundColor} 80%, transparent)` }} />
     )
-}
-
-function toRGBA(color: string, alpha: number) {
-    return `${color}${Math.round(alpha * 255).toString(16)}`;
 }

--- a/react-frontend/src/components/Button/Button.module.css
+++ b/react-frontend/src/components/Button/Button.module.css
@@ -1,0 +1,49 @@
+.button {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: center;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    background-color: var(--color-base-50);
+    color: var(--color-base-700);
+    transition: var(--transition);
+    cursor: default;
+    font-family: inherit;
+}
+
+.button:hover {
+    transform: scale(1.05);
+}
+
+.button:active {
+    transform: scale(0.95);
+    color: var(--color-base-200);
+    background-color: var(--color-base-600);
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+.ghost {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+.sm {
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+}
+
+.md {
+    font-size: 1rem;
+    padding: 0.35rem 0.6rem;
+}
+
+.lg {
+    font-size: 1rem;
+    padding: 0.5rem 1rem;
+}

--- a/react-frontend/src/components/Button/index.tsx
+++ b/react-frontend/src/components/Button/index.tsx
@@ -1,58 +1,45 @@
-/** @jsxImportSource @emotion/react */
-
-import { useCallback, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
-import { css } from '@emotion/react';
-
-const differentSizes = {
-    sm: {
-        fontSize: "0.8rem",
-        padding: "0.25rem 0.5rem",
-    },
-    md: {
-        fontSize: "1rem",
-        padding: "0.35rem 0.6rem",
-    },
-    lg: {
-        fontSize: "1rem",
-        padding: "0.5rem 1rem",
-    }
-}
+import { cx } from '../../utils/cx';
+import styles from './Button.module.css';
 
 type ButtonProps = {
     readonly icon?: React.JSX.Element;
     readonly text?: string;
     readonly onClick?: () => void;
-    readonly size?: keyof typeof differentSizes;
+    readonly size?: 'sm' | 'md' | 'lg';
+    readonly variant?: 'solid' | 'ghost';
     readonly style?: React.CSSProperties;
+    readonly className?: string;
     readonly pointer?: boolean;
-    readonly children?: React.JSX.Element[];
-}
+    readonly children?: React.ReactNode;
+};
 
-export default function Button({ icon, text, onClick, size = "lg", style, pointer, children }: ButtonProps) {
-    const { theme } = useThemeContext();
-    const buttonStyle = useMemo(() => css({
-        display: "inline-block",
-        padding: differentSizes[size].padding,
-        fontSize: differentSizes[size].fontSize,
-        cursor: pointer ? "pointer" : "default",
-        ...theme.button,
-        ...style,
-    }), [theme, size, style, pointer]);
-    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === "Enter") {
-            onClick?.();
-        }
-    }, [onClick]);
-
+export default function Button({
+    icon,
+    text,
+    onClick,
+    size = 'lg',
+    variant = 'solid',
+    style,
+    className,
+    pointer,
+    children,
+}: ButtonProps) {
     return (
-        <span
-            css={buttonStyle}
+        <button
+            type="button"
+            className={cx(
+                styles.button,
+                styles[size],
+                variant === 'ghost' && styles.ghost,
+                pointer && styles.pointer,
+                className
+            )}
+            style={style}
             onClick={onClick}
-            onKeyDown={handleKeyDown} >
+        >
             {icon}
             {text}
             {children}
-        </span >
-    )
+        </button>
+    );
 }

--- a/react-frontend/src/components/CenteredSection/Header.module.css
+++ b/react-frontend/src/components/CenteredSection/Header.module.css
@@ -1,0 +1,22 @@
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--color-base-700);
+}
+
+.line {
+    width: 100%;
+    height: 1px;
+    background-color: var(--color-base-200);
+    border: none;
+}

--- a/react-frontend/src/components/CenteredSection/Header.tsx
+++ b/react-frontend/src/components/CenteredSection/Header.tsx
@@ -1,6 +1,5 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Text from '../Text'
+import styles from './Header.module.css';
 
 type HeaderProps = {
     readonly title: string,
@@ -9,18 +8,8 @@ type HeaderProps = {
 }
 
 export default function Header({ title, subtitle, icon }: HeaderProps) {
-    const headerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-        }
-    }, []);
-
     return (
-        <header style={headerStyle}>
+        <header className={styles.header}>
             <HeaderTitle title={title} icon={icon} />
             {subtitle && <Text variant={"h3"}>{subtitle}</Text>}
             <HorizontalLine />
@@ -29,19 +18,8 @@ export default function Header({ title, subtitle, icon }: HeaderProps) {
 }
 
 function HeaderTitle({ title, icon }: Readonly<Pick<HeaderProps, "title" | "icon">>) {
-    const { theme } = useThemeContext();
-    const titleStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-            color: theme.colors.base[700],
-        }
-    }, [theme.colors]);
-
     return (
-        <div style={titleStyle}>
+        <div className={styles.title}>
             {icon}
             <Text variant={"h3"}>
                 {title}
@@ -51,17 +29,7 @@ function HeaderTitle({ title, icon }: Readonly<Pick<HeaderProps, "title" | "icon
 }
 
 function HorizontalLine() {
-    const { theme } = useThemeContext();
-    const hrStyle = useMemo((): CSSProperties => {
-        return {
-            width: "100%",
-            height: "1px",
-            backgroundColor: theme.colors.base[200],
-            border: "none",
-        }
-    }, [theme.colors]);
-
     return (
-        <hr style={hrStyle} />
+        <hr className={styles.line} />
     )
 }

--- a/react-frontend/src/components/CenteredSection/index.tsx
+++ b/react-frontend/src/components/CenteredSection/index.tsx
@@ -1,6 +1,6 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Header from './Header';
+import { cx } from '../../utils/cx';
+import surfaces from '../../styles/surfaces.module.css';
 
 type CenteredSectionProps = {
     readonly title: string,
@@ -10,17 +10,8 @@ type CenteredSectionProps = {
 }
 
 export default function CenteredSection({ title, subtitle, icon, children }: CenteredSectionProps) {
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            ...theme.container,
-            flexDirection: "column",
-            textAlign: "center",
-        }
-    }, [theme]);
-
     return (
-        <div style={containerStyle}>
+        <div className={cx(surfaces.container, surfaces.column, surfaces.center)}>
             <Header title={title} subtitle={subtitle} icon={icon} />
             {children}
         </div>

--- a/react-frontend/src/components/ContainerWrap.module.css
+++ b/react-frontend/src/components/ContainerWrap.module.css
@@ -1,0 +1,6 @@
+.container {
+    display: grid;
+    align-items: center;
+    padding-top: 70px;
+    padding-bottom: 30px;
+}

--- a/react-frontend/src/components/ContainerWrap.tsx
+++ b/react-frontend/src/components/ContainerWrap.tsx
@@ -1,16 +1,8 @@
-import { CSSProperties, FC, useMemo } from "react";
+import { FC } from "react";
 import { useTransition, animated } from "@react-spring/web";
+import styles from "./ContainerWrap.module.css";
 
 const ContainerWrap = (Component: FC) => function HOC() {
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "grid",
-            alignItems: "center",
-            paddingTop: "70px",
-            paddingBottom: "30px",
-        }
-    }, []);
-
     const transitions = useTransition(Component, {
         from: { opacity: 0, transform: "translate(-500px)" },
         enter: { opacity: 1, transform: "translate(0)" },
@@ -18,9 +10,9 @@ const ContainerWrap = (Component: FC) => function HOC() {
         config: { duration: 400 },
     });
 
-    return transitions((styles, item) => (item != null) && (
-        <animated.div style={styles}>
-            <div style={containerStyle}>
+    return transitions((style, item) => (item != null) && (
+        <animated.div style={style}>
+            <div className={styles.container}>
                 <Component />
             </div>
         </animated.div>

--- a/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.module.css
@@ -1,0 +1,4 @@
+.button {
+    margin-top: 1rem;
+    margin-right: 1rem;
+}

--- a/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.tsx
@@ -1,8 +1,10 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import Button from '../Button';
 import Header from '../MainSection/Header';
 import type { Element } from 'hast'
 import { faLink, faFileAlt } from '@fortawesome/free-solid-svg-icons';
+import styles from './AncherLinkMarkdown.module.css';
 
 type AncherLinkMarkdownProps = {
     node?: Element,
@@ -10,7 +12,7 @@ type AncherLinkMarkdownProps = {
 
 const iconType = ['doc', 'link'] as const;
 
-const iconName: Record<typeof iconType[number], any> = {
+const iconName: Record<typeof iconType[number], IconDefinition> = {
     doc: faFileAlt,
     link: faLink,
 }
@@ -31,10 +33,7 @@ const AncherLinkMarkdown = ({ node, ...props }: AncherLinkMarkdownProps) => {
                 size='md'
                 onClick={() => { window.open(link, "_blank") }}
                 pointer={true}
-                style={{
-                    marginTop: '1rem',
-                    marginRight: '1rem',
-                }}
+                className={styles.button}
             />
         )
     }

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.module.css
@@ -1,0 +1,30 @@
+.blockquote {
+    padding: 0 1rem;
+    position: relative;
+    margin: 1rem 0;
+}
+
+.bar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 5px;
+    background-color: currentColor;
+}
+
+.baseBar {
+    color: var(--color-base-700);
+}
+
+.secondaryBar {
+    color: var(--color-secondary-500);
+}
+
+.highlightBase {
+    background-color: var(--color-base-200);
+}
+
+.highlightSecondary {
+    background-color: var(--color-secondary-200);
+}

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -1,27 +1,23 @@
 import { useMemo } from 'react';
-import { useThemeContext } from '../../contexts/ThemeContext';
 import type { Element, RootContent } from 'hast'
 import MainSection from '../MainSection';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { markdownComponents } from '.';
 import { v4 as uuid } from 'uuid';
+import { cx } from '../../utils/cx';
+import styles from './BlockquoteMarkdown.module.css';
 
 type BlockquoteElementType = "highlight-background" | "without-background";
 type BlockquoteColorType = "base" | "secondary";
-type TargetElementType = Record<BlockquoteElementType, Record<BlockquoteColorType, {
-    containerBackgroundColor: string,
-    barColor: string,
-}>>
 type BlockquoteMarkdownProps = {
     node?: Element,
 } & React.HTMLAttributes<HTMLQuoteElement>;
 
 
 const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownProps) => {
-    const { theme } = useThemeContext();
     const contentJSXElementsFromAST = useMemo(() => {
-        let content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
+        const content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
             Fragment, jsx, jsxs, passNode: true, components: {
                 ...markdownComponents,
                 br: () => null,
@@ -32,33 +28,9 @@ const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownPro
         ));
     }, [node?.children]);
 
-    const targetElement = useMemo((): TargetElementType => ({
-        "highlight-background": {
-            "base": {
-                containerBackgroundColor: theme.colors.base[200],
-                barColor: theme.colors.base[700],
-            },
-            "secondary": {
-                containerBackgroundColor: theme.colors.secondary[200],
-                barColor: theme.colors.secondary[500],
-            },
-        },
-        "without-background": {
-            "base": {
-                containerBackgroundColor: "transparent",
-                barColor: theme.colors.base[700],
-            },
-            "secondary": {
-                containerBackgroundColor: "transparent",
-                barColor: theme.colors.secondary[500],
-            },
-        },
-    }), [theme.colors.base, theme.colors.secondary]);
-
     // By default it will be without-background and base color
-    let backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);
-    let colorType = useMemo((): BlockquoteColorType => className?.includes("secondary") ? "secondary" : "base", [className]);
-    let colors = useMemo(() => targetElement[backgroundType][colorType], [backgroundType, colorType, targetElement]);
+    const backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);
+    const colorType = useMemo((): BlockquoteColorType => className?.includes("secondary") ? "secondary" : "base", [className]);
 
     if (className?.includes("popup")) {
         return (
@@ -71,22 +43,12 @@ const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownPro
     return (
         <div
             {...props as React.HTMLAttributes<HTMLDivElement>}
-            style={{
-                ...props.style,
-                padding: "0 1rem",
-                position: "relative",
-                margin: "1rem 0",
-                backgroundColor: `${colors.containerBackgroundColor}`,
-                color: `${colors.barColor}`
-            }}>
-            <div style={{
-                position: "absolute",
-                left: 0,
-                height: "100%",
-                top: 0,
-                backgroundColor: `${colors.barColor}`,
-                width: "5px",
-            }} />
+            className={cx(
+                styles.blockquote,
+                colorType === "secondary" ? styles.secondaryBar : styles.baseBar,
+                backgroundType === "highlight-background" && (colorType === "secondary" ? styles.highlightSecondary : styles.highlightBase)
+            )}>
+            <div className={styles.bar} />
             {contentJSXElementsFromAST}
         </div>
     );

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -1,0 +1,52 @@
+.hr {
+    margin: 1rem 0;
+    background-color: var(--color-base-200);
+    height: 1px;
+}
+
+.ul {
+    list-style-type: none;
+}
+
+.li {
+    list-style-type: none;
+    position: relative;
+}
+
+.li::before {
+    content: ">";
+    position: absolute;
+    top: 0;
+    left: -15px;
+    font-weight: 600;
+}
+
+.h1 {
+    font-size: 3.8rem;
+    font-weight: 700;
+}
+
+.h2 {
+    font-size: 2.2rem;
+    font-weight: 700;
+}
+
+.h3 {
+    font-size: 1.8rem;
+    font-weight: 700;
+}
+
+.h4 {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
+.h5 {
+    font-size: 1.2rem;
+    font-weight: 700;
+}
+
+.h6 {
+    font-size: 1.1rem;
+    color: var(--color-base-800);
+}

--- a/react-frontend/src/components/HTMLMarkdown/HeadingMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HeadingMarkdown.tsx
@@ -1,91 +1,26 @@
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './HTMLMarkdown.module.css';
 
 type HeadingMarkdownProps = React.HTMLAttributes<HTMLHRElement> & {
     headingNumber: "one" | "two" | "three" | "four" | "five" | "six",
 }
 
+const headingClass: Record<HeadingMarkdownProps["headingNumber"], string> = {
+    one: styles.h1,
+    two: styles.h2,
+    three: styles.h3,
+    four: styles.h4,
+    five: styles.h5,
+    six: styles.h6,
+}
+
 const HeadingMarkdown = ({ headingNumber, children, ...props }: HeadingMarkdownProps) => {
-    const { theme } = useThemeContext();
-    const HTMLHeadingStyles: Record<HeadingMarkdownProps["headingNumber"], React.CSSProperties> = {
-        one: {
-            fontSize: "3.8rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        two: {
-            fontSize: "2.2rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        three: {
-            fontSize: "1.8rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        four: {
-            fontSize: "1.4rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        five: {
-            fontSize: "1.2rem",
-            fontWeight: 700,
-            // color: theme.colors.base[800]
-        },
-        six: {
-            fontSize: "1.1rem",
-            color: theme.colors.base[800]
-        }
-    }
     const HTMLHeadings: Record<HeadingMarkdownProps["headingNumber"], React.JSX.Element> = {
-        one:
-            <h1 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.one
-                }}>
-                {children}
-            </h1>,
-        two:
-            <h2 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.two
-                }}>
-                {children}
-            </h2>,
-        three:
-            <h3 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.three
-                }}>
-                {children}
-            </h3>,
-        four:
-            <h4 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.four
-                }}>
-                {children}
-            </h4>,
-        five:
-            <h5 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.five
-                }}>
-                {children}
-            </h5>,
-        six:
-            <h6 {...props}
-                style={{
-                    ...props.style,
-                    ...HTMLHeadingStyles.six
-                }}>
-                {children}
-            </h6>,
+        one: <h1 {...props} className={headingClass.one}>{children}</h1>,
+        two: <h2 {...props} className={headingClass.two}>{children}</h2>,
+        three: <h3 {...props} className={headingClass.three}>{children}</h3>,
+        four: <h4 {...props} className={headingClass.four}>{children}</h4>,
+        five: <h5 {...props} className={headingClass.five}>{children}</h5>,
+        six: <h6 {...props} className={headingClass.six}>{children}</h6>,
     }
 
     return HTMLHeadings[headingNumber];

--- a/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
@@ -1,18 +1,8 @@
-import { useMemo } from 'react';
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './HTMLMarkdown.module.css';
 
 const HrMarkdown = ({ ...props }: React.HTMLAttributes<HTMLHRElement>) => {
-    const { theme } = useThemeContext();
-    const elementStyle = useMemo(() => ({
-        margin: "1rem 0",
-        backgroundColor: theme.colors.base[200],
-        height: "1px",
-    }), [theme.colors.base]);
     return (
-        <div {...props} style={{
-            ...props.style,
-            ...elementStyle,
-        }} />
+        <div {...props} className={styles.hr} />
     )
 }
 

--- a/react-frontend/src/components/HTMLMarkdown/LiMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/LiMarkdown.tsx
@@ -1,22 +1,7 @@
-/** @jsxImportSource @emotion/react */
-
-import { Interpolation, Theme } from "@emotion/react"
-import { useMemo } from "react"
+import styles from './HTMLMarkdown.module.css';
 
 const LiMarkdown = ({ ...props }: React.HTMLAttributes<HTMLLIElement>) => {
-    const elementStyle = useMemo((): Interpolation<Theme> => ({
-        listStyleType: "none",
-        position: "relative",
-        "&::before": {
-            content: '">"',
-            position: "absolute",
-            top: 0,
-            left: -15,
-            fontWeight: 600
-        }
-    }), [])
-    
-    return (<li {...props} css={elementStyle}>
+    return (<li {...props} className={styles.li}>
         {props.children}
     </li>)
 }

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.module.css
@@ -1,0 +1,24 @@
+.highlightAreaBase {
+    font-weight: 600;
+    color: var(--color-base-800);
+    background: linear-gradient(to bottom, transparent 60%, var(--color-base-200) 60%);
+}
+
+.highlightAreaSecondary {
+    font-weight: 600;
+    color: var(--color-base-800);
+    background: linear-gradient(to bottom, transparent 60%, var(--color-secondary-300) 60%);
+}
+
+.highlightTextBase {
+    font-weight: 600;
+}
+
+.highlightTextSecondary {
+    font-weight: 600;
+    color: var(--color-secondary-500);
+}
+
+.button {
+    margin: 0.5rem;
+}

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -1,28 +1,37 @@
-import { CSSProperties, useMemo } from 'react';
-import { useThemeContext } from '../../contexts/ThemeContext';
+import { useMemo } from 'react';
 import type { Element, RootContent } from 'hast'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { markdownComponents } from '.';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import Button from '../Button';
 import { v4 as uuid } from 'uuid';
+import styles from './SpanMarkdown.module.css';
 
 
 type SpanElementType = "highlight-area" | "highlight-text";
 type SpanColorType = "base" | "secondary";
-type TargetElementType = Record<SpanElementType, Record<SpanColorType, CSSProperties>>;
 
 type SpanMarkdownProps = {
     node?: Element,
 } & React.HTMLAttributes<HTMLSpanElement>;
 
+const variantClass: Record<SpanElementType, Record<SpanColorType, string>> = {
+    "highlight-area": {
+        "base": styles.highlightAreaBase,
+        "secondary": styles.highlightAreaSecondary,
+    },
+    "highlight-text": {
+        "base": styles.highlightTextBase,
+        "secondary": styles.highlightTextSecondary,
+    },
+};
+
 const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
-    const { theme } = useThemeContext();
     const classes = useMemo(() => className?.split(" ") ?? [], [className]);
     const contentJSXElementsFromAST = useMemo(() => {
-        let content = node?.children;
+        const content = node?.children;
         if (typeof content === 'string') return content;
-        let result = node?.children.map((element) => toJsxRuntime(element as RootContent, {
+        const result = node?.children.map((element) => toJsxRuntime(element as RootContent, {
             Fragment, jsx, jsxs, passNode: true, components: {
                 ...markdownComponents,
                 br: () => null,
@@ -32,52 +41,18 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
             <Fragment key={uuid()}>{element}</Fragment>
         ));
     }, [node?.children]);
-    const targetElement = useMemo((): TargetElementType => ({
-        "highlight-area": {
-            "base": {
-                fontWeight: 600,
-                color: theme.colors.base[800],
-                background: `linear-gradient(to bottom, transparent 60%, ${theme.colors.base[200]} 60%)`,
-            },
-            "secondary": {
-                fontWeight: 600,
-                color: theme.colors.base[800],
-                background: `linear-gradient(to bottom, transparent 60%, ${theme.colors.secondary[300]} 60%)`
-            },
-        },
-        "highlight-text": {
-            "base": {
-                fontWeight: 600,
-            },
-            "secondary": {
-                color: theme.colors.secondary[500],
-                fontWeight: 600,
-            },
-        },
-    }), [theme.colors.base, theme.colors.secondary]);
     const spanElement = useMemo((): SpanElementType => {
         return classes.includes("highlight-area") ? "highlight-area" : "highlight-text";
     }, [classes]);
     const colorType = useMemo((): SpanColorType => {
         return classes.includes("secondary") ? "secondary" : "base";
     }, [classes]);
-    const { style, children } = useMemo((): { style: CSSProperties, children: React.ReactNode } => {
-        return {
-            style: {
-                ...props.style,
-                ...targetElement[spanElement][colorType],
-            },
-            children: contentJSXElementsFromAST
-        };
-    }, [props.style, contentJSXElementsFromAST, targetElement, spanElement, colorType]);
 
     // `[[Button]]`
     if (classes.includes("button")) {
         return (
             <Button
-                style={{
-                    margin: "0.5rem",
-                }}
+                className={styles.button}
                 key={classes.join()}
                 size='sm'>
                 {contentJSXElementsFromAST}
@@ -86,8 +61,8 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
     }
 
     return (
-        <span {...props} style={style}>
-            {children}
+        <span {...props} className={variantClass[spanElement][colorType]}>
+            {contentJSXElementsFromAST}
         </span>
     );
 }

--- a/react-frontend/src/components/HTMLMarkdown/UlMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/UlMarkdown.tsx
@@ -1,10 +1,8 @@
+import styles from './HTMLMarkdown.module.css';
+
 const UlMarkdown = ({ ...props }: React.HTMLAttributes<HTMLUListElement>) => {
     return (
-        <ul {...props}
-            style={{
-                ...props.style,
-                listStyleType: "none"
-            }} />
+        <ul {...props} className={styles.ul} />
     )
 }
 

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
@@ -7,7 +7,7 @@ export const customBlockquote = () => {
     return function (tree: Node) {
         visit(tree, 'blockquote', (node: Blockquote) => {
             findAndReplace(node, [
-                /\[!([^\[]+)\]\s?([a-z]*)/,
+                /\[!([^[]+)\]\s?([a-z]*)/,
                 (fullText, variation, titleText, matchedNode) => {
                     // To modfiy the parent node (Blockquote) of the matched text
                     matchedNode.stack[matchedNode.stack.length - 3].data = {

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customHighlightText.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customHighlightText.ts
@@ -1,7 +1,7 @@
 import { findAndReplace } from 'mdast-util-find-and-replace'
 import { visit } from 'unist-util-visit';
 import type { Node } from 'hast'
-import { Nodes, Parent } from 'mdast'
+import { Nodes, Parent, PhrasingContent } from 'mdast'
 import { toString } from 'mdast-util-to-string'
 
 const textVariationsRegexReplace = {
@@ -29,7 +29,7 @@ const handleVariationReplace = (variation: typeof textVariationsRegexReplace[key
     let isMatched = false;
     findAndReplace(node, [
         variation.regex,
-        (fullText: any, content: any) => {
+        (fullText: string, content: string) => {
             isMatched = true;
             return {
                 type: 'strong',
@@ -44,7 +44,7 @@ const handleVariationReplace = (variation: typeof textVariationsRegexReplace[key
                         className: variation.replace.className,
                     }
                 }
-            } as any;
+            } as unknown as PhrasingContent;
         }
     ])
     return isMatched;

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
@@ -3,7 +3,7 @@ import { Nodes, Parent, Image, RootContent } from 'mdast'
 import { toString } from 'mdast-util-to-string'
 
 
-let imageRegex = /!\[([^\]]+)\]\(([^ ]+)\s?(?:=(?:(\d+)x(\d+)|(h|w)(\d+)))?(?:\|(center|left|right))?\)/;
+const imageRegex = /!\[([^\]]+)\]\(([^ ]+)\s?(?:=(?:(\d+)x(\d+)|(h|w)(\d+)))?(?:\|(center|left|right))?\)/;
 
 const imageNodeStyle: React.CSSProperties = ({
     maxWidth: `inherit`,
@@ -50,7 +50,7 @@ const imageContainerStyle = (align: string): React.CSSProperties => {
 export const customImage = () => {
     return function (tree: Nodes) {
         visit(tree, 'paragraph', (node: Nodes) => {
-            let nodeFullText = toString(node);
+            const nodeFullText = toString(node);
             const match = imageRegex.exec(nodeFullText);
             if (match) {
                 const fragments = nodeFullText.split(imageRegex);

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureButton.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureButton.ts
@@ -3,7 +3,7 @@ import type { customType } from '.'
 
 export const captureButton = (node: Node): customType => ({
     regex: /\[\[([a-zA-Z0-9\s]+)\]\]/,
-    callback: (fullText: any, content: any) => {
+    callback: (fullText: string, content: string) => {
         return {
             type: 'strong',
             children: [

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
@@ -1,9 +1,10 @@
 import type { Node } from 'hast'
+import type { PhrasingContent } from 'mdast'
 import type { customType } from '.'
 
 export const captureGap = (node: Node): customType => ({
     regex: /\[gap\]/,
-    callback: (fullText: any) => ({
+    callback: (fullText: string) => ({
         type: 'paragraph',
         children: [],
         data: {
@@ -11,5 +12,5 @@ export const captureGap = (node: Node): customType => ({
                 style: "margin: 0 1rem 1rem 0; display: inline-block;"
             }
         }
-    } as any)
+    } as unknown as PhrasingContent)
 })

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
@@ -1,9 +1,10 @@
 import type { Node } from 'hast'
+import type { PhrasingContent } from 'mdast'
 import type { customType } from '.'
 
 export const captureNewline = (node: Node): customType => ({
     regex: /\[newline\]/,
-    callback: (fullText: any) => {
+    callback: (fullText: string) => {
         return ({
             type: 'paragraph',
             children: [],
@@ -12,6 +13,6 @@ export const captureNewline = (node: Node): customType => ({
                     style: "margin: 0.5rem 0; display: grid;"
                 }
             }
-        } as any)
+        } as unknown as PhrasingContent)
     }
 })

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureTextDirection.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureTextDirection.ts
@@ -3,7 +3,7 @@ import type { customType } from '.'
 
 export const captureTextDirection = (node: Node): customType => ({
     regex: /\[(center|left|right)\]/,
-    callback: (fullText: any, align: any) => {
+    callback: (fullText: string, align: string) => {
         node.data = {
             hProperties: {
                 style: "text-align: " + align

--- a/react-frontend/src/components/Icon/Icon.module.css
+++ b/react-frontend/src/components/Icon/Icon.module.css
@@ -1,0 +1,65 @@
+.icon {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: center;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    background-color: var(--color-base-50);
+    color: var(--color-base-700);
+    transition: var(--transition);
+    cursor: default;
+}
+
+.icon:hover {
+    transform: scale(1.05);
+}
+
+.icon:active {
+    transform: scale(0.95);
+    color: var(--color-base-200);
+    background-color: var(--color-base-600);
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+.lg {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+}
+
+.md {
+    padding: 0.4rem 0.9rem;
+    font-size: 0.8rem;
+}
+
+.imageFrame {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--color-base-50);
+    border: var(--border);
+    overflow: hidden;
+    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.2));
+}
+
+.lg .imageFrame {
+    width: 70px;
+    height: 70px;
+}
+
+.md .imageFrame {
+    width: 50px;
+    height: 50px;
+}
+
+.image {
+    width: 70%;
+    object-fit: cover;
+    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.5));
+}

--- a/react-frontend/src/components/Icon/index.tsx
+++ b/react-frontend/src/components/Icon/index.tsx
@@ -1,24 +1,6 @@
-/** @jsxImportSource @emotion/react */
-
-import { CSSProperties, useCallback, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Text from '../Text';
-import { css } from '@emotion/react';
-
-const variants = {
-    "lg": {
-        outerPadding: "0.5rem 1rem",
-        imageWidth: "70px",
-        imageHeight: "70px",
-        fontSize: "1rem",
-    },
-    "md": {
-        outerPadding: "0.4rem 0.9rem",
-        imageWidth: "50px",
-        imageHeight: "50px",
-        fontSize: "0.8rem",
-    },
-}
+import { cx } from '../../utils/cx';
+import styles from './Icon.module.css';
 
 type IconProps = {
     readonly src?: string;
@@ -26,8 +8,8 @@ type IconProps = {
     readonly text?: string;
     readonly pointer?: boolean;
     readonly onClick?: () => void;
-    readonly size?: keyof typeof variants;
-}
+    readonly size?: 'lg' | 'md';
+};
 
 export default function Icon({
     src,
@@ -35,52 +17,27 @@ export default function Icon({
     text,
     pointer = false,
     onClick,
-    size = "md"
+    size = 'md',
 }: IconProps) {
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo(() => css({
-        flexDirection: "column",
-        padding: variants[size].outerPadding,
-        cursor: pointer ? "pointer" : "default",
-        fontSize: variants[size].fontSize,
-        ...theme.button,
-    }), [theme, pointer, size]);
-    const imageFrameStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: variants[size].imageWidth,
-            height: variants[size].imageHeight,
-            borderRadius: "50%",
-            backgroundColor: theme.colors.base[50],
-            border: theme.border,
-            overflow: "hidden",
-            filter: "drop-shadow(0px 0px 2px rgba(0,0,0,0.2))",
-        };
-    }, [theme, size]);
-    const imageStyle = useMemo((): CSSProperties => {
-        return {
-            width: "70%",
-            objectFit: "cover",
-            filter: "drop-shadow(0px 0px 2px rgba(0,0,0,0.5))",
-        };
-    }, []);
-    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === "Enter") {
-            onClick?.();
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (onClick && (event.key === 'Enter' || event.key === ' ')) {
+            event.preventDefault();
+            onClick();
         }
-    }, [onClick]);
+    };
 
     return (
         <div
-            css={outerStyle}
+            className={cx(styles.icon, styles[size], pointer && styles.pointer)}
             onClick={onClick}
-            onKeyDown={handleKeyDown} >
-            <div style={imageFrameStyle}>
-                <img style={imageStyle} src={src ?? "images/placeholder.png"} alt={alt} />
+            onKeyDown={handleKeyDown}
+            role={onClick ? 'button' : undefined}
+            tabIndex={onClick ? 0 : undefined}
+        >
+            <div className={styles.imageFrame}>
+                <img className={styles.image} src={src ?? 'images/placeholder.png'} alt={alt} />
             </div>
-            {text && <Text variant={"body"}>{text}</Text>}
+            {text && <Text variant={'body'}>{text}</Text>}
         </div>
-    )
+    );
 }

--- a/react-frontend/src/components/ListButtons.module.css
+++ b/react-frontend/src/components/ListButtons.module.css
@@ -1,0 +1,7 @@
+.list {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 1rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/components/ListButtons.tsx
+++ b/react-frontend/src/components/ListButtons.tsx
@@ -1,23 +1,13 @@
-import { CSSProperties, useMemo } from 'react';
 import Button from './Button'
+import styles from './ListButtons.module.css';
 
 type ListButtonsProps = {
     readonly elements: string[];
 }
 
 export default function ListButtons({ elements }: ListButtonsProps) {
-    const mainListStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap",
-        }
-    }, []);
-
     return (
-        <div style={mainListStyle}>
+        <div className={styles.list}>
             {elements.map((tech) => {
                 return (
                     <Button key={tech} text={tech} size='sm' />

--- a/react-frontend/src/components/Loader/Loader.module.css
+++ b/react-frontend/src/components/Loader/Loader.module.css
@@ -1,0 +1,9 @@
+.loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.spinner {
+    color: var(--color-base-700);
+}

--- a/react-frontend/src/components/Loader/index.tsx
+++ b/react-frontend/src/components/Loader/index.tsx
@@ -1,24 +1,11 @@
-import { useMemo } from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './Loader.module.css';
 
 export default function Loader() {
-    const { theme } = useThemeContext();
-
-    const containerStyle = useMemo(() => ({
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-    }), []);
-
     return (
-        <div style={containerStyle}>
-            <FontAwesomeIcon
-            style={{
-                color: theme.colors.base[700],
-            }}
-            icon={faSpinner} size="2x" spin />
+        <div className={styles.loader}>
+            <FontAwesomeIcon className={styles.spinner} icon={faSpinner} size="2x" spin />
         </div>
     )
 }

--- a/react-frontend/src/components/MainSection/Content.module.css
+++ b/react-frontend/src/components/MainSection/Content.module.css
@@ -1,0 +1,10 @@
+.content {
+    display: flex;
+    justify-content: flex-start;
+    gap: 1rem;
+    align-items: stretch;
+}
+
+.grow {
+    flex-grow: 1;
+}

--- a/react-frontend/src/components/MainSection/Content.tsx
+++ b/react-frontend/src/components/MainSection/Content.tsx
@@ -1,24 +1,13 @@
-import { CSSProperties, useMemo } from 'react'
+import styles from './Content.module.css';
 
 type ContentProps = {
     readonly children: React.ReactNode,
 }
 
 export default function Content({ children }: ContentProps) {
-    const mainStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            alignItems: "stretch",
-        }
-    }, []);
-
     return (
-        <main style={mainStyle}>
-            <div style={{
-                flexGrow: 1,
-            }}>
+        <main className={styles.content}>
+            <div className={styles.grow}>
                 {children}
             </div>
         </main>

--- a/react-frontend/src/components/MainSection/Header.module.css
+++ b/react-frontend/src/components/MainSection/Header.module.css
@@ -1,0 +1,15 @@
+.headerContainer {
+    display: inline;
+}
+
+.headerText {
+    display: inline;
+}
+
+.linkText {
+    display: inline-block;
+}
+
+.pointer {
+    cursor: pointer;
+}

--- a/react-frontend/src/components/MainSection/Header.tsx
+++ b/react-frontend/src/components/MainSection/Header.tsx
@@ -1,7 +1,12 @@
-import { CSSProperties, useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import Text from '../Text';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { cx } from '../../utils/cx';
+import styles from './Header.module.css';
+
+const titleTextStyle = { display: 'inline', marginRight: '0.5rem' } as const;
+const iconTextStyle = { display: 'inline-block' } as const;
 
 type HeaderProps = {
     readonly title: string,
@@ -10,45 +15,29 @@ type HeaderProps = {
 }
 
 export default function Header({ title, link, subtitle }: HeaderProps) {
-    const headerConatinerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "inline",
-            alignItems: "center",
-            gap: "0.5rem",
-        }
-    }, []);
-
-    const headerTextStyle = useMemo((): CSSProperties => {
-        return {
-            // color: theme.colors.base[600],
-            display: "inline",
-            marginRight: "0.5rem",
-            cursor: link ? "pointer" : "default",
-        }
-    }, [link]);
-
     const headerOnCLickHandler = useCallback(() => {
-        link && window.open(link, "_blank");
+        if (link) {
+            window.open(link, "_blank");
+        }
     }, [link]);
 
     return (
         <>
-            <div style={headerConatinerStyle}>
+            <div className={styles.headerContainer}>
                 <Text
                     variant={"h3"}
-                    onClick={headerOnCLickHandler}
-                    style={headerTextStyle}>
-                    {title}
+                    onClick={link ? headerOnCLickHandler : undefined}
+                    style={titleTextStyle}>
+                    <span className={cx(styles.headerText, link && styles.pointer)}>{title}</span>
                 </Text>
                 {link && (
                     <Text
                         variant={"h3"}
                         onClick={headerOnCLickHandler}
-                        style={{
-                            display: "inline-block",
-                            cursor: link ? "pointer" : "default",
-                            }}>
-                        <ExternalLinkIcon />
+                        style={iconTextStyle}>
+                        <span className={cx(styles.linkText, styles.pointer)}>
+                            <ExternalLinkIcon />
+                        </span>
                     </Text>
                 )}
             </div>

--- a/react-frontend/src/components/MainSection/HeaderSymbol.module.css
+++ b/react-frontend/src/components/MainSection/HeaderSymbol.module.css
@@ -1,0 +1,17 @@
+.symbol {
+    width: 20px;
+    height: 20px;
+    background-color: var(--color-base-50);
+    border: var(--border);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dot {
+    width: 70%;
+    height: 70%;
+    border-radius: 50%;
+    background-color: var(--color-base-500);
+}

--- a/react-frontend/src/components/MainSection/HeaderSymbol.tsx
+++ b/react-frontend/src/components/MainSection/HeaderSymbol.tsx
@@ -1,28 +1,9 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
+import styles from './HeaderSymbol.module.css';
 
 export default function HeaderSymbol() {
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo((): CSSProperties => ({
-        width: "20px",
-        height: "20px",
-        backgroundColor: theme.colors.base[50],
-        border: theme.border,
-        borderRadius: "50%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-    }), [theme]);
-    const innerStyle = useMemo((): CSSProperties => ({
-        width: "70%",
-        height: "70%",
-        borderRadius: "50%",
-        backgroundColor: theme.colors.base[500],
-    }), [theme]);
-
     return (
-        <div style={outerStyle}>
-            <div style={innerStyle} />
+        <div className={styles.symbol}>
+            <div className={styles.dot} />
         </div>
     )
 }

--- a/react-frontend/src/components/MainSection/index.tsx
+++ b/react-frontend/src/components/MainSection/index.tsx
@@ -1,7 +1,7 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Header from './Header';
 import Content from './Content';
+import { cx } from '../../utils/cx';
+import surfaces from '../../styles/surfaces.module.css';
 
 type MainSectionProps = {
     readonly title?: string,
@@ -14,17 +14,8 @@ type MainSectionProps = {
 export default function MainSection({ title, link, subtitle, style, children }:
     MainSectionProps
 ) {
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            ...theme.container,
-            flexDirection: "column",
-            ...style,
-        }
-    }, [theme, style]);
-
     return (
-        <div style={containerStyle}>
+        <div className={cx(surfaces.container, surfaces.column)} style={style}>
             {title && <Header title={title} link={link} subtitle={subtitle} />}
             <Content>
                 {children}

--- a/react-frontend/src/components/Navbar/Links/LinkButton.module.css
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.module.css
@@ -1,0 +1,3 @@
+.link {
+    font-weight: 500;
+}

--- a/react-frontend/src/components/Navbar/Links/LinkButton.tsx
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.tsx
@@ -2,7 +2,7 @@ import Button from '../../Button'
 import { PortfolioPathes } from '../../../Types';
 import { memo, useMemo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './LinkButton.module.css';
 
 type LinkButtonProps = {
     readonly path: PortfolioPathes,
@@ -11,23 +11,23 @@ type LinkButtonProps = {
 }
 
 function LinkButton({ path, pageName, onClick }: LinkButtonProps) {
-    const { theme } = useThemeContext();
     const navigate = useNavigate();
     const active = useMatch(`/${path}`);
+    // Active/inactive colours depend on the current route, so they stay as
+    // token-based inline styles; the ghost variant strips the default border/shadow.
     const linkButtonStyle = useMemo(() => {
         const linkActive = active !== null;
         return {
-            boxShadow: "none",
-            border: "none",
-            backgroundColor: linkActive ? theme.colors.base[200] : "",
-            color: linkActive ? theme.colors.base[800] : theme.colors.base[400],
-            opacity: linkActive ? "1" : "0.9",
-            fontWeight: "500",
-        }
-    }, [theme.colors.base, active]);
+            backgroundColor: linkActive ? 'var(--color-base-200)' : 'transparent',
+            color: linkActive ? 'var(--color-base-800)' : 'var(--color-base-400)',
+            opacity: linkActive ? 1 : 0.9,
+        };
+    }, [active]);
 
     return (
         <Button
+            variant="ghost"
+            className={styles.link}
             style={linkButtonStyle}
             pointer={true}
             size='md'

--- a/react-frontend/src/components/Navbar/Links/NormalLinks/NormalLinks.module.css
+++ b/react-frontend/src/components/Navbar/Links/NormalLinks/NormalLinks.module.css
@@ -1,0 +1,6 @@
+.links {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}

--- a/react-frontend/src/components/Navbar/Links/NormalLinks/index.tsx
+++ b/react-frontend/src/components/Navbar/Links/NormalLinks/index.tsx
@@ -1,16 +1,9 @@
-import { useMemo } from 'react';
 import PortfolioLinks from '../PortfolioLinks';
+import styles from './NormalLinks.module.css';
 
 export default function NormalLinks() {
-    const linksContainerStyle = useMemo(() => ({
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: "1rem",
-    }), []);
-
     return (
-        <div style={linksContainerStyle}>
+        <div className={styles.links}>
             <PortfolioLinks />
         </div>
     )

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.module.css
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.module.css
@@ -1,0 +1,5 @@
+.bars {
+    display: inline-block;
+    color: var(--color-base-400);
+    cursor: pointer;
+}

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.tsx
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/BarsIcon.tsx
@@ -1,27 +1,31 @@
-import { useThemeContext } from '../../../../contexts/ThemeContext';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBars } from '@fortawesome/free-solid-svg-icons';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
+import styles from './BarsIcon.module.css';
 
 type BarsIconProps = {
     readonly setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 function BarsIcon({ setIsMenuOpen }: BarsIconProps) {
-    const { theme } = useThemeContext();
-    const barsStyle = useMemo(() => ({
-        display: "inline-block",
-        color: theme.colors.base[400],
-        cursor: "pointer",
-    }), [theme.colors]);
     const clickHandler = useCallback(() => {
         setIsMenuOpen((oldIsMenuOpen) => !oldIsMenuOpen);
     }, [setIsMenuOpen]);
+    const keyDownHandler = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            clickHandler();
+        }
+    }, [clickHandler]);
 
     return (
         <div
-            style={barsStyle}
-            onClick={clickHandler} >
+            className={styles.bars}
+            role="button"
+            tabIndex={0}
+            aria-label="Open navigation menu"
+            onClick={clickHandler}
+            onKeyDown={keyDownHandler} >
             <FontAwesomeIcon icon={faBars} size={"xl"} />
         </div>
     )

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/DropDownLinks.module.css
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/DropDownLinks.module.css
@@ -1,0 +1,32 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    transform-origin: top;
+    transition: var(--transition);
+}
+
+.overlayOpen {
+    left: 0;
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    background-color: var(--color-base-50);
+}

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.module.css
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.module.css
@@ -1,0 +1,7 @@
+.exit {
+    width: fit-content;
+    margin: 0 auto;
+    border-radius: 50%;
+    padding: 0.7rem;
+    color: var(--color-base-600);
+}

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.tsx
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/ExitButton.tsx
@@ -1,30 +1,21 @@
-import { useCallback, useMemo } from 'react'
 import Button from '../../../../Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
-import { useThemeContext } from '../../../../../contexts/ThemeContext';
+import styles from './ExitButton.module.css';
 
 type ExitButtonProps = {
     readonly setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export default function ExitButton({ setIsMenuOpen }: ExitButtonProps) {
-    const { theme } = useThemeContext();
-    const buttonStyle = useMemo(() => ({
-        width: 'fit-content',
-        margin: '0 auto',
-        cursor: 'pointer',
-        borderRadius: '50%',
-        padding: '0.7rem',
-        color: theme.colors.base[600],
-    }), [theme.colors]);
-    const buttonClickHandler = useCallback(() => {
+    const buttonClickHandler = () => {
         setIsMenuOpen(false);
-    }, [setIsMenuOpen]);
+    };
 
     return (
         <Button
-            style={buttonStyle}
+            className={styles.exit}
+            pointer={true}
             icon={<FontAwesomeIcon icon={faCircleXmark} transform="grow-12" />}
             onClick={buttonClickHandler} />
     )

--- a/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/index.tsx
+++ b/react-frontend/src/components/Navbar/Links/ToggledLinks/DropDownLinks/index.tsx
@@ -1,8 +1,8 @@
-import { CSSProperties, useCallback, useMemo } from "react";
-import { useThemeContext } from '../../../../../contexts/ThemeContext';
 import PortfolioLinks from "../../PortfolioLinks";
 import BlurBackground from "../../../../BlurBackground";
 import ExitButton from "./ExitButton";
+import { cx } from "../../../../../utils/cx";
+import styles from "./DropDownLinks.module.css";
 
 type DropDownLinksProps = {
     readonly isMenuOpen: boolean,
@@ -10,41 +10,15 @@ type DropDownLinksProps = {
 }
 
 export default function DropDownLinks({ isMenuOpen, setIsMenuOpen }: DropDownLinksProps) {
-    const { theme } = useThemeContext();
-    const linksContainerStyle = useMemo((): CSSProperties => ({
-        position: "fixed",
-        top: "0",
-        right: "0",
-        left: isMenuOpen ? "0" : "100%",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        gap: "1rem",
-        padding: "2rem",
-        width: "100%",
-        overflow: "hidden",
-        transformOrigin: "top",
-        transition: theme.transition,
-        height: '100%',
-    }), [isMenuOpen, theme.transition]);
-    const linkButtonsContainerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        gap: "1rem",
-        ...theme.boxingStyle,
-        backgroundColor: theme.colors.base[50],
-        padding: "2rem",
-    }), [theme.boxingStyle, theme.colors]);
-    const linkButtonOnClickHandler = useCallback(() => {
+    const linkButtonOnClickHandler = () => {
         setIsMenuOpen(false);
-    }, [setIsMenuOpen]);
+    };
 
     return (
-        <div style={linksContainerStyle}>
-            <BlurBackground backgroundColor={theme.colors.base[400]} />
+        <div className={cx(styles.overlay, isMenuOpen && styles.overlayOpen)}>
+            <BlurBackground backgroundColor={'var(--color-base-400)'} />
             <ExitButton setIsMenuOpen={setIsMenuOpen} />
-            <div style={linkButtonsContainerStyle}>
+            <div className={styles.panel}>
                 <PortfolioLinks
                     linkButtonOnClickHandler={linkButtonOnClickHandler} />
             </div>

--- a/react-frontend/src/components/Navbar/Logo.module.css
+++ b/react-frontend/src/components/Navbar/Logo.module.css
@@ -1,0 +1,9 @@
+.logo {
+    color: var(--color-base-100);
+    cursor: pointer;
+}
+
+.text {
+    font-size: 1.5rem;
+    font-weight: 700;
+}

--- a/react-frontend/src/components/Navbar/Logo.tsx
+++ b/react-frontend/src/components/Navbar/Logo.tsx
@@ -1,11 +1,10 @@
 import { useCallback } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Text from '../Text'
 import { SanityNavbarData } from '../../Types';
 import { useNavigate } from 'react-router-dom';
+import styles from './Logo.module.css';
 
 export default function Logo({ logo }: Readonly<Pick<SanityNavbarData, "logo">>) {
-    const { theme } = useThemeContext();
     const navigate = useNavigate();
 
     const changeLinksHandler = useCallback(() => navigate(''), [navigate]);
@@ -17,17 +16,13 @@ export default function Logo({ logo }: Readonly<Pick<SanityNavbarData, "logo">>)
 
     return (
         <div
-            style={{
-                color: theme.colors.base[100],
-                cursor: "pointer",
-            }}
+            className={styles.logo}
+            role="button"
+            tabIndex={0}
             onClick={changeLinksHandler}
             onKeyDown={onKeyDownHandler} >
-            <Text variant={"h2"} style={{
-                fontSize: "1.5rem",
-                fontWeight: "700",
-            }}>
-                {logo}
+            <Text variant={"h2"}>
+                <span className={styles.text}>{logo}</span>
             </Text>
         </div>
     )

--- a/react-frontend/src/components/Navbar/Navbar.module.css
+++ b/react-frontend/src/components/Navbar/Navbar.module.css
@@ -1,0 +1,21 @@
+.navbar {
+    position: sticky;
+    padding: 1rem;
+    max-width: 1255px;
+    top: 20px;
+    z-index: 999;
+    background-color: var(--color-base-900);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+    max-width: 1255px;
+    margin: 0 auto;
+    padding: 0 1rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/components/Navbar/index.tsx
+++ b/react-frontend/src/components/Navbar/index.tsx
@@ -1,44 +1,17 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import Logo from './Logo'
 import Links from './Links';
 import { SanityNavbarData } from '../../Types';
 import { getNavbarData } from '../../APIs';
 import Loader from '../Loader';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from './Navbar.module.css';
 
 export default function Navbar() {
-    const [navbarData, setNavbarData] = useState<SanityNavbarData | null>(null);
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo((): CSSProperties => ({
-        position: "sticky",
-        padding: "1rem",
-        maxWidth: "1255px",
-        top: "20px",
-        zIndex: "999",
-        backgroundColor: theme.colors.base[900],
-        ...theme.boxingStyle,
-        border: "none",
-    }), [theme]);
-    const innerStyle = useMemo((): CSSProperties => ({
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        height: "100%",
-        maxWidth: "1255px",
-        margin: "0 auto",
-        padding: "0 1rem",
-        flexWrap: "wrap",
-    }), []);
-
-    useEffect(() => {
-        getNavbarData().then((data) => {
-            setNavbarData(data);
-        });
-    }, []);
+    const { data: navbarData } = useSanityQuery<SanityNavbarData>(getNavbarData);
 
     return (
-        <div style={outerStyle}>
-            <div style={innerStyle}>
+        <div className={styles.navbar}>
+            <div className={styles.inner}>
                 {navbarData ? <Logo logo={navbarData.logo} /> : <Loader />}
                 <Links />
             </div>

--- a/react-frontend/src/components/ProjectCard/Content.module.css
+++ b/react-frontend/src/components/ProjectCard/Content.module.css
@@ -1,0 +1,12 @@
+.content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.links {
+    display: flex;
+    gap: 1rem;
+}

--- a/react-frontend/src/components/ProjectCard/Content.tsx
+++ b/react-frontend/src/components/ProjectCard/Content.tsx
@@ -1,8 +1,9 @@
-import { CSSProperties, memo, useMemo } from 'react'
+import { memo } from 'react'
 import ListButtons from '../ListButtons';
 import ProjectButton from './Image/ImageOverlay/ProjectButton';
 import DemoButton from './Image/ImageOverlay/DemoButton';
 import HTMLMarkdown from '../HTMLMarkdown';
+import styles from './Content.module.css';
 
 type ContentProps = {
     readonly title?: string,
@@ -13,24 +14,10 @@ type ContentProps = {
 }
 
 function Content({ title, description, technologies, projectLink, demoLink }: ContentProps) {
-    const outerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            justifyContent: "space-between",
-            gap: "1rem",
-        }
-    }, []);
-    const linksStyle = useMemo(() => ({
-        display: "flex",
-        gap: "1rem",
-    }), []);
-
     return (
-        <div style={outerStyle}>
+        <div className={styles.content}>
             <HTMLMarkdown markdown={description} />
-            <div style={linksStyle}>
+            <div className={styles.links}>
                 {projectLink && <ProjectButton projectLink={projectLink} />}
                 {demoLink && <DemoButton demoLink={demoLink} />}
             </div>

--- a/react-frontend/src/components/ProjectCard/Image/Image.module.css
+++ b/react-frontend/src/components/ProjectCard/Image/Image.module.css
@@ -1,0 +1,17 @@
+.frame {
+    max-width: 350px;
+    height: auto;
+    overflow: hidden;
+    border-radius: var(--radius);
+    border: var(--border);
+    box-shadow: var(--shadow);
+    position: relative;
+    flex: 0 0 auto;
+}
+
+@media (max-width: 768px) {
+    .frame {
+        max-width: 100%;
+        height: 250px;
+    }
+}

--- a/react-frontend/src/components/ProjectCard/Image/ImageOverlay/ImageOverlay.module.css
+++ b/react-frontend/src/components/ProjectCard/Image/ImageOverlay/ImageOverlay.module.css
@@ -1,0 +1,22 @@
+.overlay {
+    z-index: 1;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    transition: var(--transition);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    border-radius: var(--radius);
+}
+
+.overlayHovered {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/react-frontend/src/components/ProjectCard/Image/ImageOverlay/index.tsx
+++ b/react-frontend/src/components/ProjectCard/Image/ImageOverlay/index.tsx
@@ -1,34 +1,16 @@
-/** @jsxImportSource @emotion/react */
-
-import { useMemo, CSSProperties, memo } from 'react'
-import { useThemeContext } from '../../../../contexts/ThemeContext';
+import { memo } from 'react'
 import BlurBackground from '../../../BlurBackground';
+import { cx } from '../../../../utils/cx';
+import styles from './ImageOverlay.module.css';
 
 type ImageOverlayProps = {
     readonly isHovered: boolean,
 }
 
 function ImageOverlay({ isHovered }: ImageOverlayProps) {
-    const { theme } = useThemeContext();
-    const imageOverlayStyle = useMemo((): CSSProperties => ({
-        zIndex: 1,
-        position: "absolute",
-        top: isHovered ? 0 : "50%",
-        left: isHovered ? 0 : "50%",
-        width: isHovered ? "100%" : "0%",
-        height: isHovered ? "100%" : "0%",
-        overflow: "hidden",
-        transition: theme.transition,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "1rem",
-        borderRadius: theme.borderRadius,
-    }), [theme, isHovered]);
-
     return (
-        <div style={imageOverlayStyle}>
-            <BlurBackground backgroundColor={theme.colors.base[700]} />
+        <div className={cx(styles.overlay, isHovered && styles.overlayHovered)}>
+            <BlurBackground backgroundColor={'var(--color-base-700)'} />
         </div>
     )
 }

--- a/react-frontend/src/components/ProjectCard/Image/MainImage.module.css
+++ b/react-frontend/src/components/ProjectCard/Image/MainImage.module.css
@@ -1,0 +1,6 @@
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: var(--transition);
+}

--- a/react-frontend/src/components/ProjectCard/Image/MainImage.tsx
+++ b/react-frontend/src/components/ProjectCard/Image/MainImage.tsx
@@ -1,18 +1,11 @@
 import { memo } from "react"
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './MainImage.module.css';
 
 function MainImage({ imgSrc, isHovered }: { imgSrc: string, isHovered: boolean }) {
-    const { theme } = useThemeContext();
-
     return (
         <img
-            style={{ 
-                transition: theme.transition ,
-                width: "100%", 
-                height: "100%", 
-                objectFit: "cover", 
-                scale: isHovered ? "1.2" : "1"
-            }}
+            className={styles.image}
+            style={{ scale: isHovered ? "1.2" : "1" }}
             src={imgSrc}
             alt={imgSrc} />
     )

--- a/react-frontend/src/components/ProjectCard/Image/index.tsx
+++ b/react-frontend/src/components/ProjectCard/Image/index.tsx
@@ -1,28 +1,13 @@
-import { useState, useMemo, CSSProperties } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext';
-// import ImageOverlay from './ImageOverlay';
+import { useState } from 'react'
 import MainImage from './MainImage';
+import styles from './Image.module.css';
 
 export type ImageProps = {
     readonly imgSrc: string,
-    readonly isSmallScreen: boolean,
 }
 
-export default function Image({ imgSrc, isSmallScreen }: ImageProps) {
+export default function Image({ imgSrc }: ImageProps) {
     const [isHovered, setIsHovered] = useState(false);
-    const { theme } = useThemeContext();
-    const imageFrameStyle = useMemo((): CSSProperties => {
-        return {
-            maxWidth: isSmallScreen ? "100%" : "350px",
-            height: isSmallScreen ? "250px" : "auto",
-            overflow: "hidden",
-            borderRadius: theme.borderRadius,
-            border: `1px solid ${theme.colors.base}`,
-            boxShadow: theme.boxShadow,
-            position: "relative",
-            flex: "0 0 auto"
-        }
-    }, [theme, isSmallScreen]);
 
     return (
         <div
@@ -30,9 +15,8 @@ export default function Image({ imgSrc, isSmallScreen }: ImageProps) {
             onFocus={() => { setIsHovered(true) }}
             onMouseOut={() => { setIsHovered(false) }}
             onBlur={() => { setIsHovered(false) }}
-            style={imageFrameStyle} >
+            className={styles.frame} >
             <MainImage imgSrc={imgSrc} isHovered={isHovered} />
-            {/* <ImageOverlay isHovered={isHovered} /> */}
         </div>
     )
 }

--- a/react-frontend/src/components/ProjectCard/ProjectCard.module.css
+++ b/react-frontend/src/components/ProjectCard/ProjectCard.module.css
@@ -1,0 +1,12 @@
+.card {
+    align-items: stretch;
+    justify-content: flex-start;
+    flex-direction: row;
+    height: auto;
+}
+
+@media (max-width: 768px) {
+    .card {
+        flex-direction: column;
+    }
+}

--- a/react-frontend/src/components/ProjectCard/index.tsx
+++ b/react-frontend/src/components/ProjectCard/index.tsx
@@ -1,8 +1,9 @@
-import { CSSProperties, memo, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
-import { useMediaQuery } from 'react-responsive';
+import { memo } from 'react'
 import Image from './Image';
 import Content from './Content';
+import { cx } from '../../utils/cx';
+import surfaces from '../../styles/surfaces.module.css';
+import styles from './ProjectCard.module.css';
 
 type ProjectCardProps = {
     readonly imgSrc?: string,
@@ -21,23 +22,9 @@ function ProjectCard({
     description,
     technologies
 }: ProjectCardProps) {
-    const { theme } = useThemeContext();
-    const isSmallScreen = useMediaQuery({ query: '(max-width: 768px)' });
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            alignItems: "stretch",
-            justifyContent: "flex-start",
-            flexDirection: isSmallScreen ? "column" : "row",
-            height: "auto",
-            ...theme.container,
-        }
-    }, [theme, isSmallScreen]);
-
     return (
-        <div style={containerStyle}>
-            <Image
-                imgSrc={imgSrc || "images/placeholder.png"}
-                isSmallScreen={isSmallScreen} />
+        <div className={cx(surfaces.container, styles.card)}>
+            <Image imgSrc={imgSrc || "images/placeholder.png"} />
             <Content 
                 description={description} 
                 technologies={technologies}

--- a/react-frontend/src/components/SectionError/SectionError.module.css
+++ b/react-frontend/src/components/SectionError/SectionError.module.css
@@ -1,0 +1,5 @@
+.error {
+    text-align: center;
+    color: var(--color-base-600);
+    padding: 2rem;
+}

--- a/react-frontend/src/components/SectionError/index.tsx
+++ b/react-frontend/src/components/SectionError/index.tsx
@@ -1,0 +1,15 @@
+import styles from './SectionError.module.css';
+
+type SectionErrorProps = {
+    readonly message?: string;
+};
+
+export default function SectionError({
+    message = 'Something went wrong loading this section. Please try again later.',
+}: SectionErrorProps) {
+    return (
+        <p className={styles.error} role="alert">
+            {message}
+        </p>
+    );
+}

--- a/react-frontend/src/components/SectionTitle/SectionTitle.module.css
+++ b/react-frontend/src/components/SectionTitle/SectionTitle.module.css
@@ -1,0 +1,21 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    text-align: center;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    font-size: 1.2rem;
+    flex-wrap: wrap;
+}
+
+.text {
+    color: var(--color-base-800);
+}

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/ActualText.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/ActualText.tsx
@@ -1,20 +1,9 @@
 import Text from '../../Text'
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext'
+import styles from './highlight.module.css';
 
 function ActualText({ text }: { readonly text: string }) {
-    const { theme } = useThemeContext();
-    const style = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        borderRadius: "inherit",
-        backgroundColor: theme.colors.secondary[300],
-        padding: "10px 1.4rem",
-    }), [theme.colors]);
-    
     return (
-        <div style={style}>
+        <div className={styles.actual}>
             <Text variant={"h2"}>{text}</Text>
         </div>
     );

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/Shadow.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/Shadow.tsx
@@ -1,23 +1,8 @@
-import { CSSProperties, useMemo } from 'react';
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './highlight.module.css';
 
 function Shadow() {
-    const { theme } = useThemeContext();
-
-    const style = useMemo((): CSSProperties => ({
-        width: "inherit",
-        height: "inherit",
-        position: "absolute",
-        zIndex: "-2",
-        backgroundColor: theme.colors.base[800],
-        bottom: "-3px",
-        left: "3px",
-        margin: "auto",
-        borderRadius: "inherit", 
-    }), []);
-    
     return (
-        <div style={style} />
+        <div className={styles.shadow} />
     );
 }
 

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/Stroke.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/Stroke.tsx
@@ -1,22 +1,8 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext'
+import styles from './highlight.module.css';
 
 function Stroke() {
-    const { theme } = useThemeContext();
-    const style = useMemo((): CSSProperties => ({
-        width: "calc(100% - 10px)",
-        height: "calc(100% - 10px)",
-        position: "absolute",
-        zIndex: "1",
-        border: `3px solid ${theme.colors.base[800]}`,
-        top: "5px",
-        left: "5px",
-        margin: "auto",
-        borderRadius: "inherit", 
-    }), [theme.colors]);
-    
     return (
-        <div style={style} />
+        <div className={styles.stroke} />
     );
 }
 

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/highlight.module.css
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/highlight.module.css
@@ -1,0 +1,41 @@
+.highlight {
+    color: var(--color-base-900);
+    box-shadow: var(--shadow);
+    position: relative;
+    rotate: -3deg;
+    z-index: 1;
+    border-radius: var(--radius);
+}
+
+.shadow {
+    width: inherit;
+    height: inherit;
+    position: absolute;
+    z-index: -2;
+    background-color: var(--color-base-800);
+    bottom: -3px;
+    left: 3px;
+    margin: auto;
+    border-radius: inherit;
+}
+
+.stroke {
+    width: calc(100% - 10px);
+    height: calc(100% - 10px);
+    position: absolute;
+    z-index: 1;
+    border: 3px solid var(--color-base-800);
+    top: 5px;
+    left: 5px;
+    margin: auto;
+    border-radius: inherit;
+}
+
+.actual {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: inherit;
+    background-color: var(--color-secondary-300);
+    padding: 10px 1.4rem;
+}

--- a/react-frontend/src/components/SectionTitle/TitleHighlightedText/index.tsx
+++ b/react-frontend/src/components/SectionTitle/TitleHighlightedText/index.tsx
@@ -1,24 +1,11 @@
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../../contexts/ThemeContext';
 import ActualText from './ActualText';
 import Shadow from './Shadow';
 import Stroke from './Stroke';
+import styles from './highlight.module.css';
 
 function TitleHighlightedText({ children }: { readonly children: string }) {
-    const { theme } = useThemeContext();
-    const outerStyle = useMemo((): CSSProperties => {
-        return {
-            color: theme.colors.base[900],
-            boxShadow: theme.boxShadow,
-            position: "relative",
-            rotate: "-3deg",
-            zIndex: "1",
-            borderRadius: theme.borderRadius
-        };
-    }, [theme]);
-
     return (
-        <div style={outerStyle}>
+        <div className={styles.highlight}>
             <Stroke />
             <Shadow />
             <ActualText text={children} />

--- a/react-frontend/src/components/SectionTitle/index.tsx
+++ b/react-frontend/src/components/SectionTitle/index.tsx
@@ -1,7 +1,6 @@
 import Text from '../Text'
-import { CSSProperties, useMemo } from 'react'
-import { useThemeContext } from '../../contexts/ThemeContext';
 import TitleHighlightedText from './TitleHighlightedText';
+import styles from './SectionTitle.module.css';
 
 type SectionTitleProps = {
     readonly highlightedText?: string;
@@ -11,34 +10,11 @@ type SectionTitleProps = {
 }
 
 export default function SectionTitle({ highlightedText, text, subtitle, style }: SectionTitleProps) {
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.5rem",
-            ...style,
-            textAlign: "center",
-        };
-    }, [style]);
-    const titleStyle = useMemo((): CSSProperties => {
-        return {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "1rem",
-            fontSize: "1.2rem",
-            flexWrap: "wrap",
-        };
-    }, []);
-
     return (
-        <header style={containerStyle}>
-            <div style={titleStyle}>
+        <header className={styles.container} style={style}>
+            <div className={styles.title}>
                 {highlightedText ? <TitleHighlightedText>{highlightedText}</TitleHighlightedText> : null}
-                {text ? <Text style={{color: theme.colors.base[800]}} variant={"h2"}>{text}</Text> : null}
+                {text ? <Text variant={"h2"}><span className={styles.text}>{text}</span></Text> : null}
             </div>
             {subtitle ? <Text variant={"h3"}>{subtitle}</Text> : null}
         </header>

--- a/react-frontend/src/components/Text/index.tsx
+++ b/react-frontend/src/components/Text/index.tsx
@@ -1,45 +1,41 @@
-import { CSSProperties, ReactNode } from "react"
+import { CSSProperties, ReactNode, KeyboardEvent } from 'react';
+
+const variantTags = {
+    h1: 'h1',
+    h2: 'h2',
+    h3: 'h3',
+    h4: 'h4',
+    body: 'p',
+} as const;
 
 type TextProps = {
-    readonly variant?: keyof typeof TextVariants,
-    readonly style?: CSSProperties,
-    readonly onClick?: () => void,
-    readonly children: ReactNode,
-}
+    readonly variant?: keyof typeof variantTags;
+    readonly style?: CSSProperties;
+    readonly onClick?: () => void;
+    readonly children: ReactNode;
+};
 
-const TextVariants = {
-    h1: ({ style, onClick, children }: TextProps) =>
-        <h1 onClick={onClick}
-            onKeyDown={onClick}
-            style={style}
-            tabIndex={0}
-        >{children}</h1>,
-    h2: ({ style, onClick, children }: TextProps) =>
-        <h2 onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</h2>,
-    h3: ({ style, onClick, children }: TextProps) =>
-        <h3 onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</h3>,
-    h4: ({ style, onClick, children }: TextProps) =>
-        <h4 onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</h4>,
-    body: ({ style, onClick, children }: TextProps) =>
-        <p onClick={onClick}
-            onKeyDown={onClick}
-            tabIndex={0}
-            style={style}
-        >{children}</p>,
-}
+export default function Text({ variant = 'body', style, onClick, children }: TextProps) {
+    const Tag = variantTags[variant];
 
-export default function Text({ variant = "body", style, onClick, children }: TextProps) {
-    return TextVariants[variant]({ style, onClick, children });
+    // Only expose keyboard/focus affordances when the node is actually interactive.
+    const interactiveProps = onClick
+        ? {
+              role: 'button' as const,
+              tabIndex: 0,
+              onClick,
+              onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onClick();
+                  }
+              },
+          }
+        : {};
+
+    return (
+        <Tag style={style} {...interactiveProps}>
+            {children}
+        </Tag>
+    );
 }

--- a/react-frontend/src/containers/About/About.module.css
+++ b/react-frontend/src/containers/About/About.module.css
@@ -1,0 +1,7 @@
+.container {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+}

--- a/react-frontend/src/containers/About/Content/Content.module.css
+++ b/react-frontend/src/containers/About/Content/Content.module.css
@@ -1,0 +1,11 @@
+.content {
+    font-size: 1.2rem;
+    color: var(--color-base-800);
+    text-align: left;
+}
+
+@media (max-width: 1124px) {
+    .content {
+        text-align: center;
+    }
+}

--- a/react-frontend/src/containers/About/Content/index.tsx
+++ b/react-frontend/src/containers/About/Content/index.tsx
@@ -1,24 +1,13 @@
-/** @jsxImportSource @emotion/react */
-
-import { useMediaQuery } from 'react-responsive';
-import { CSSProperties, memo, useMemo } from 'react';
+import { memo } from 'react';
 import { SanityAboutPage } from '../../../Types';
-import { useThemeContext } from '../../../contexts/ThemeContext';
 import HTMLMarkdown from '../../../components/HTMLMarkdown';
+import styles from './Content.module.css';
 
 function Content({
     description,
 }: Readonly<Omit<SanityAboutPage, 'personImage'>>) {
-    const isMediumScreen = useMediaQuery({ query: '(max-width: 1124px)' });
-    const { theme } = useThemeContext();
-    const containerStyle = useMemo((): CSSProperties => ({
-        fontSize: "1.2rem",
-        color: theme.colors.base[800],
-        textAlign: isMediumScreen ? "center" : "left",
-    }), [isMediumScreen, theme.colors.base]);
-
     return (
-        <div style={containerStyle}>
+        <div className={styles.content}>
             <HTMLMarkdown markdown={description} />
         </div>
     )

--- a/react-frontend/src/containers/About/Image/ActualImage.tsx
+++ b/react-frontend/src/containers/About/Image/ActualImage.tsx
@@ -1,32 +1,12 @@
-import { CSSProperties, useMemo } from 'react';
 import { SanityAboutPage } from '../../../Types';
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './Image.module.css';
 
 export default function ActualImage({ personImage }: Readonly<Pick<SanityAboutPage, 'personImage'>>) {
-    const { theme } = useThemeContext();
-    const imageFrameStyle = useMemo((): CSSProperties => ({
-        width: "100%",
-        height: "100%",
-        borderRadius: "50%",
-        overflow: "hidden",
-        position: "absolute",
-        boxShadow: theme.boxShadow,
-        top: "0",
-        left: "0",
-        zIndex: "2",
-        border: `3px solid ${theme.colors.base[50]}`,
-    }), [theme]);
-    const imageStyle = useMemo((): CSSProperties => ({
-        width: "100%",
-        height: "100%",
-        objectFit: "cover",
-    }), []);
-
     return (
-        <div style={imageFrameStyle}>
+        <div className={styles.imageFrame}>
             <img src={personImage}
                 alt="Shawky Ebrahim"
-                style={imageStyle} />
+                className={styles.image} />
         </div>
     )
 }

--- a/react-frontend/src/containers/About/Image/BackShape.tsx
+++ b/react-frontend/src/containers/About/Image/BackShape.tsx
@@ -1,17 +1,7 @@
-import { useThemeContext } from '../../../contexts/ThemeContext';
+import styles from './Image.module.css';
 
 export default function BackShape() {
-    const { theme } = useThemeContext();
-
     return (
-        <div style={{
-            width: "inherit",
-            height: "inherit",
-            position: "absolute",
-            borderRadius: "50%",
-            zIndex: "1",
-            scale: "1.1",
-            border: `3px solid ${theme.colors.base[700]}`,
-        }} />
+        <div className={styles.backShape} />
     )
 }

--- a/react-frontend/src/containers/About/Image/Image.module.css
+++ b/react-frontend/src/containers/About/Image/Image.module.css
@@ -1,0 +1,35 @@
+.frame {
+    width: 320px;
+    height: 320px;
+    position: relative;
+    margin-right: 10px;
+}
+
+.backShape {
+    width: inherit;
+    height: inherit;
+    position: absolute;
+    border-radius: 50%;
+    z-index: 1;
+    scale: 1.1;
+    border: 3px solid var(--color-base-700);
+}
+
+.imageFrame {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    overflow: hidden;
+    position: absolute;
+    box-shadow: var(--shadow);
+    top: 0;
+    left: 0;
+    z-index: 2;
+    border: 3px solid var(--color-base-50);
+}
+
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}

--- a/react-frontend/src/containers/About/Image/index.tsx
+++ b/react-frontend/src/containers/About/Image/index.tsx
@@ -1,18 +1,12 @@
-import { CSSProperties, memo, useMemo } from 'react';
+import { memo } from 'react';
 import BackShape from './BackShape';
 import ActualImage from './ActualImage';
 import { SanityAboutPage } from '../../../Types';
+import styles from './Image.module.css';
 
 function Image({ personImage }: Readonly<Pick<SanityAboutPage, 'personImage'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        width: "320px",
-        height: "320px",
-        position: "relative",
-        marginRight: "10px",
-    }), []);
-
     return (
-        <div style={containerStyle}>
+        <div className={styles.frame}>
             <BackShape />
             <ActualImage personImage={personImage} />
         </div>

--- a/react-frontend/src/containers/About/index.tsx
+++ b/react-frontend/src/containers/About/index.tsx
@@ -1,38 +1,26 @@
 import ContainerWrap from '../../components/ContainerWrap'
 import Content from './Content';
 import Image from './Image';
-import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { SanityAboutPage } from '../../Types';
 import { getAboutPage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from './About.module.css';
 
 function About() {
-    const [aboutPage, setAboutPage] = useState<SanityAboutPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column-reverse",
-        justifyContent: "space-between",
-        alignItems: "center",
-        gap: "2rem",
-    }), []);
+    const { data: aboutPage, error } = useSanityQuery<SanityAboutPage>(getAboutPage);
 
-    useEffect(() => {
-        getAboutPage().then((result) => {
-            setAboutPage(result);
-        });
-    }, []);
+    if (error) return <SectionError />;
+    if (!aboutPage) return <Loader />;
 
     return (
-        <>
-            {aboutPage ? (
-                <div style={containerStyle}>
-                    <Content
-                        description={aboutPage.description}
-                    />
-                    <Image personImage={aboutPage.personImage} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.container}>
+            <Content
+                description={aboutPage.description}
+            />
+            <Image personImage={aboutPage.personImage} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Contacts/Content.module.css
+++ b/react-frontend/src/containers/Contacts/Content.module.css
@@ -1,0 +1,7 @@
+.contacts {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/containers/Contacts/Content.tsx
+++ b/react-frontend/src/containers/Contacts/Content.tsx
@@ -1,16 +1,11 @@
 import { memo } from "react";
 import { SanityContactsPage } from "../../Types";
 import Icon from "../../components/Icon";
+import styles from "./Content.module.css";
 
 function Content({ contacts }: Readonly<Pick<SanityContactsPage, "contacts">>) {
     return (
-        <div style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "2rem",
-            flexWrap: "wrap",
-        }}>
+        <div className={styles.contacts}>
             {contacts.map((contact) => {
                 return (
                     <Icon

--- a/react-frontend/src/containers/Contacts/index.tsx
+++ b/react-frontend/src/containers/Contacts/index.tsx
@@ -1,36 +1,24 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
 import ContainerWrap from '../../components/ContainerWrap';
 import { getContactsPage } from '../../APIs';
 import { SanityContactsPage } from '../../Types';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Content from './Content';
 import Title from '../Title';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Contacts() {
-    const [contactsPage, setContactsPage] = useState<SanityContactsPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: contactsPage, error } = useSanityQuery<SanityContactsPage>(getContactsPage);
 
-    useEffect(() => {
-        getContactsPage().then((result) => {
-            setContactsPage(result);
-        })
-    }, []);
+    if (error) return <SectionError />;
+    if (!contactsPage) return <Loader />;
 
     return (
-        <>
-            {contactsPage ? (
-                <div style={containerStyle}>
-                    <Title title={contactsPage.title} />
-                    <Content contacts={contactsPage.contacts} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={contactsPage.title} />
+            <Content contacts={contactsPage.contacts} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Education/Content/CoursesItems.tsx
+++ b/react-frontend/src/containers/Education/Content/CoursesItems.tsx
@@ -1,23 +1,18 @@
 import ListButtons from '../../../components/ListButtons'
-import { CSSProperties, memo, useMemo } from 'react';
+import { memo } from 'react';
 import { SanityEducationPage } from '../../../Types';
 import HTMLMarkdown from '../../../components/HTMLMarkdown';
 import MainSection from '../../../components/MainSection';
+import surfaces from '../../../styles/surfaces.module.css';
 
 function CoursesItems({ courses }: Readonly<Pick<SanityEducationPage["education"], "courses">>) {
-    const innerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {courses.map((course, index) => {
                 return (
                     <MainSection
                         key={course.description}>
-                        <div style={innerStyle}>
+                        <div className={surfaces.stack}>
                             <HTMLMarkdown markdown={course.description} />
                             {course.technologies && <ListButtons elements={course.technologies} />}
                         </div>

--- a/react-frontend/src/containers/Education/Content/index.tsx
+++ b/react-frontend/src/containers/Education/Content/index.tsx
@@ -1,21 +1,15 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { memo } from "react";
 import { SanityEducationPage } from "../../../Types";
 import MainSection from "../../../components/MainSection";
 import CoursesItems from "./CoursesItems";
 import HTMLMarkdown from "../../../components/HTMLMarkdown";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ education }: Readonly<Pick<SanityEducationPage, "education">>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <MainSection
             subtitle={education.description}>
-            <div style={containerStyle}>
+            <div className={surfaces.stack}>
                 <div>
                     <HTMLMarkdown markdown={education.description} />
                 </div>

--- a/react-frontend/src/containers/Education/index.tsx
+++ b/react-frontend/src/containers/Education/index.tsx
@@ -1,36 +1,24 @@
 import ContainerWrap from '../../components/ContainerWrap'
-import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { SanityEducationPage } from '../../Types';
 import { getEducationPage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Title from '../Title';
 import Content from './Content';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Education() {
-    const [educationPage, setEducationPage] = useState<SanityEducationPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: educationPage, error } = useSanityQuery<SanityEducationPage>(getEducationPage);
 
-    useEffect(() => {
-        getEducationPage().then((result) => {
-            setEducationPage(result);
-        });
-    }, []);
+    if (error) return <SectionError />;
+    if (!educationPage) return <Loader />;
 
     return (
-        <>
-            {educationPage ? (
-                <div style={containerStyle}>
-                    <Title title={educationPage.title} />
-                    <Content education={educationPage.education} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={educationPage.title} />
+            <Content education={educationPage.education} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Experience/Certificates/Content.tsx
+++ b/react-frontend/src/containers/Experience/Certificates/Content.tsx
@@ -1,20 +1,13 @@
-import { CSSProperties, useMemo } from "react";
 import { SanityExperiencePage } from "../../../Types";
 import ExperienceItemDescription from "../ExperienceItemDescription";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ certificates }: Readonly<Pick<SanityExperiencePage['certificatesSection'], 'certificates'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {certificates.map((certificate) => {
                 return (
-                    <div style={containerStyle} key={certificate.description}>
+                    <div className={surfaces.stack} key={certificate.description}>
                         {certificate.description && <ExperienceItemDescription description={certificate.description} />}
                     </div>
                 )

--- a/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.module.css
+++ b/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.module.css
@@ -1,0 +1,7 @@
+.group {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    width: fit-content;
+    gap: 0.5rem;
+}

--- a/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.tsx
+++ b/react-frontend/src/containers/Experience/Certificates/SubtitleAndDate.tsx
@@ -1,5 +1,5 @@
 import Text from '../../../components/Text'
-import { CSSProperties, useMemo } from 'react'
+import styles from './SubtitleAndDate.module.css'
 
 type SubtitleAndDateProps = {
     readonly subTitle: string,
@@ -7,16 +7,8 @@ type SubtitleAndDateProps = {
 }
 
 export default function SubtitleAndDate({ subTitle, date }: SubtitleAndDateProps) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        alignItems: "flex-start",
-        flexDirection: "column",
-        width: "fit-content",
-        gap: "0.5rem",
-    }), []);
-
     return (
-        <div style={containerStyle}>
+        <div className={styles.group}>
             <Text variant={"h4"}>
                 {subTitle}
             </Text>

--- a/react-frontend/src/containers/Experience/Internships/Content.tsx
+++ b/react-frontend/src/containers/Experience/Internships/Content.tsx
@@ -1,20 +1,13 @@
-import { CSSProperties, useMemo } from "react";
 import { SanityExperiencePage } from "../../../Types";
 import ExperienceItemDescription from "../ExperienceItemDescription";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ internships }: Readonly<Pick<SanityExperiencePage['internshipsSection'], 'internships'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {internships.map((internship) => {
                 return (
-                    <div style={containerStyle} key={internship.description}>
+                    <div className={surfaces.stack} key={internship.description}>
                         <ExperienceItemDescription description={internship.description} />
                     </div>
                 )

--- a/react-frontend/src/containers/Experience/ProfessionalExperience/Content.tsx
+++ b/react-frontend/src/containers/Experience/ProfessionalExperience/Content.tsx
@@ -1,20 +1,13 @@
-import { CSSProperties, useMemo } from "react";
 import { SanityExperiencePage } from "../../../Types";
 import ExperienceItemDescription from "../ExperienceItemDescription";
+import surfaces from "../../../styles/surfaces.module.css";
 
 function Content({ professionalExperience }: Readonly<Pick<SanityExperiencePage['professionalExperienceSection'], 'professionalExperience'>>) {
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-        gap: "1rem",
-    }), []);
-
     return (
         <>
             {professionalExperience.map((experience) => {
                 return (
-                    <div style={containerStyle} key={experience.description}>
+                    <div className={surfaces.stack} key={experience.description}>
                         <ExperienceItemDescription description={experience.description} />
                     </div>
                 )

--- a/react-frontend/src/containers/Experience/index.tsx
+++ b/react-frontend/src/containers/Experience/index.tsx
@@ -1,38 +1,26 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
 import ContainerWrap from '../../components/ContainerWrap'
 import { SanityExperiencePage } from '../../Types';
 import Certificates from './Certificates';
 import { getExperiencePage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Internships from './Internships';
 import ProfessionalExperience from './ProfessionalExperience';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Experience() {
-    const [experiences, setExperiences] = useState<SanityExperiencePage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: experiences, error } = useSanityQuery<SanityExperiencePage>(getExperiencePage);
 
-    useEffect(() => {
-        getExperiencePage().then((result) => {
-            setExperiences(result);
-        });
-    }, []);
+    if (error) return <SectionError />;
+    if (!experiences) return <Loader />;
 
     return (
-        <>
-            {experiences ? (
-                <div style={containerStyle}>
-                    <ProfessionalExperience professionalExperienceSection={experiences.professionalExperienceSection} />
-                    <Internships internshipsSection={experiences.internshipsSection} />
-                    <Certificates certificatesSection={experiences.certificatesSection} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <ProfessionalExperience professionalExperienceSection={experiences.professionalExperienceSection} />
+            <Internships internshipsSection={experiences.internshipsSection} />
+            <Certificates certificatesSection={experiences.certificatesSection} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/MarkdownEditor/MarkdownEditor.module.css
+++ b/react-frontend/src/containers/MarkdownEditor/MarkdownEditor.module.css
@@ -1,0 +1,25 @@
+.editor {
+    display: grid;
+}
+
+.textarea {
+    flex: 1;
+    min-height: 150px;
+    padding: 15px;
+    font-size: 16px;
+    resize: vertical;
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    outline: none;
+    font-family: Arial, sans-serif;
+    line-height: 1.5;
+    margin-bottom: 20px;
+    transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.preview {
+    flex: 1;
+    padding: 10px;
+    border-top: var(--border);
+}

--- a/react-frontend/src/containers/MarkdownEditor/index.tsx
+++ b/react-frontend/src/containers/MarkdownEditor/index.tsx
@@ -1,6 +1,7 @@
-import React, { CSSProperties, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import HTMLMarkdown from '../../components/HTMLMarkdown';
 import ContainerWrap from '../../components/ContainerWrap';
+import styles from './MarkdownEditor.module.css';
 
 const MarkdownEditor = () => {
     const [markdown, setMarkdown] = useState<string>('');
@@ -9,31 +10,15 @@ const MarkdownEditor = () => {
         setMarkdown(event.target.value);
     };
 
-    const textAreaStyle = useMemo((): CSSProperties => ({
-        flex: 1,
-        minHeight: '150px',
-        padding: '15px',
-        fontSize: '16px',
-        resize: 'vertical',
-        border: '1px solid #ccc',
-        borderRadius: '8px',
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-        outline: 'none',
-        fontFamily: 'Arial, sans-serif',
-        lineHeight: '1.5',
-        marginBottom: '20px',
-        transition: 'border-color 0.3s, box-shadow 0.3s',
-    }), []);
-
     return (
-        <div style={{ display: 'grid' }}>
+        <div className={styles.editor}>
             <textarea
-                style={textAreaStyle}
+                className={styles.textarea}
                 value={markdown}
                 onChange={handleMarkdownChange}
                 placeholder="Write your Markdown here..."
             />
-            <div style={{ flex: 1, padding: '10px', borderTop: '1px solid #ccc' }}>
+            <div className={styles.preview}>
                 <HTMLMarkdown markdown={markdown} />
             </div>
         </div>

--- a/react-frontend/src/containers/Projects/index.tsx
+++ b/react-frontend/src/containers/Projects/index.tsx
@@ -1,36 +1,24 @@
-import { CSSProperties, useEffect, useMemo, useState } from 'react'
-import ContainerWrap from '../../components/ContainerWrap';
+import ContainerWrap from '../../components/ContainerWrap'
 import { SanityProjectsPage } from '../../Types';
 import { getProjectsPage } from '../../APIs';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
 import Title from '../Title';
 import Content from './Content';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Projects() {
-    const [projects, setProjects] = useState<SanityProjectsPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: projects, error } = useSanityQuery<SanityProjectsPage>(getProjectsPage);
 
-    useEffect(() => {
-        getProjectsPage().then((result) => {
-            setProjects(result);
-        })
-    }, []);
+    if (error) return <SectionError />;
+    if (!projects) return <Loader />;
 
     return (
-        <>
-            {projects ? (
-                <div style={containerStyle}>
-                    <Title title={projects.title} />
-                    <Content projects={projects.projects} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={projects.title} />
+            <Content projects={projects.projects} />
+        </div>
     )
 }
 

--- a/react-frontend/src/containers/Skills/Content/Content.module.css
+++ b/react-frontend/src/containers/Skills/Content/Content.module.css
@@ -1,0 +1,7 @@
+.list {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}

--- a/react-frontend/src/containers/Skills/Content/index.tsx
+++ b/react-frontend/src/containers/Skills/Content/index.tsx
@@ -1,19 +1,11 @@
-import { CSSProperties, useMemo } from 'react';
 import { SanitySkillsPage } from '../../../Types';
 import CenteredSection from '../../../components/CenteredSection';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from '@fortawesome/free-solid-svg-icons';
 import SkillsIcons from './SkillsIcons';
+import styles from './Content.module.css';
 
 export default function Content({ categories }: Readonly<Pick<SanitySkillsPage, "categories">>) {
-    const listItemsContainerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "1rem",
-        flexWrap: "wrap",
-    }), []);
-
     return (
         <>
             {categories.map((category) => {
@@ -22,7 +14,7 @@ export default function Content({ categories }: Readonly<Pick<SanitySkillsPage, 
                         key={category.title}
                         icon={<HeaderIcon />}
                         title={category.title} >
-                        <div style={listItemsContainerStyle}>
+                        <div className={styles.list}>
                             <SkillsIcons skills={category.skills} />
                         </div>
                     </CenteredSection>

--- a/react-frontend/src/containers/Skills/index.tsx
+++ b/react-frontend/src/containers/Skills/index.tsx
@@ -1,36 +1,24 @@
 import ContainerWrap from '../../components/ContainerWrap'
 import Content from './Content';
-import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { SanitySkillsPage } from '../../Types';
 import { getSkillsPage } from '../../APIs';
 import Title from '../Title';
 import Loader from '../../components/Loader';
+import SectionError from '../../components/SectionError';
+import { useSanityQuery } from '../../hooks/useSanityQuery';
+import styles from '../../styles/section.module.css';
 
 function Skills() {
-    const [skillsPage, setSkillsPage] = useState<SanitySkillsPage | null>(null);
-    const containerStyle = useMemo((): CSSProperties => ({
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-        gap: "2rem",
-    }), []);
+    const { data: skillsPage, error } = useSanityQuery<SanitySkillsPage>(getSkillsPage);
 
-    useEffect(() => {
-        getSkillsPage().then((result) => {
-            setSkillsPage(result)
-        })
-    }, [])
+    if (error) return <SectionError />;
+    if (!skillsPage) return <Loader />;
 
     return (
-        <>
-            {skillsPage ? (
-                <div style={containerStyle}>
-                    <Title title={skillsPage.title} />
-                    <Content categories={skillsPage.categories} />
-                </div>
-            ) : <Loader />}
-        </>
+        <div className={styles.section}>
+            <Title title={skillsPage.title} />
+            <Content categories={skillsPage.categories} />
+        </div>
     )
 }
 

--- a/react-frontend/src/contexts/ThemeContext.tsx
+++ b/react-frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 import backgroundImage from '../assets/background.svg';
-import { Theme } from '../Types';
+import { ColorLevels, Theme } from '../Types';
 
 type ThemeContextType = {
     theme: Theme,
@@ -9,52 +9,33 @@ type ThemeContextType = {
 
 const Context = createContext<ThemeContextType | null>(null);
 
-// Colors generate from: https://accessiblepalette.com/?lightness=98.2,93.95,85.1,76.5,67.65,57,47,40.4,24,16&5DACC9=1,0&f2f3ea=1,0
+// Token values live in src/styles/tokens.css. The theme references them as
+// CSS custom properties so JS-driven styles and *.module.css stay in sync.
+
+const colorRamp = (name: "base" | "secondary"): ColorLevels =>
+    ([0, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const).reduce(
+        (ramp, level) => ({ ...ramp, [level]: `var(--color-${name}-${level})` }),
+        {} as ColorLevels
+    );
 
 const colors = {
-    base: {
-        0: "#FFFFFF",
-        50: "#FAFAF6",
-        100: "#EDEEE6",
-        200: "#D4D5CD",
-        300: "#BDBDB6",
-        400: "#A5A59F",
-        500: "#898984",
-        600: "#6F706C",
-        700: "#545451",
-        800: "#393937",
-        900: "#282827",
-    },
-    secondary: {
-        0: "#FFFFFF",
-        50: "#FEF9F5",
-        100: "#FBEBDD",
-        200: "#F8D7BC",
-        300: "#F6C29A",
-        400: "#D4986C",
-        500: "#B4805B",
-        600: "#93684B",
-        700: "#7C573F",
-        800: "#644633",
-        900: "#4A3326",
-    },
-    opacity: (percentage: number) => `rgba(255,255,255,${percentage})`,
+    base: colorRamp("base"),
+    secondary: colorRamp("secondary"),
+    opacity: (percentage: number): string => `rgba(255,255,255,${percentage})`,
 }
 
 const themeProperties: Theme = {
     colors,
-    transition: "all 0.3s ease-out",
-    borderRadius: "8px",
-    boxShadow: "rgba(0, 0, 0, 0.24) 0px 3px 8px",
+    transition: "var(--transition)",
+    borderRadius: "var(--radius)",
+    boxShadow: "var(--shadow)",
     backgroundImage: `url(${backgroundImage})`,
-    border: '',
+    border: "var(--border)",
     boxingStyle: {},
     button: {},
     container: {},
     buttonEffects: {},
 };
-
-themeProperties.border = `1px solid ${themeProperties.colors.base[50]}`;
 
 themeProperties.boxingStyle = {
     border: themeProperties.border,

--- a/react-frontend/src/hooks/useSanityQuery.ts
+++ b/react-frontend/src/hooks/useSanityQuery.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+type QueryState<T> = {
+    data: T | null;
+    loading: boolean;
+    error: Error | null;
+};
+
+/**
+ * Fetches data from a Sanity query function with loading/error state.
+ *
+ * Replaces the repeated useState(null) + useEffect(fetch) pattern across
+ * containers and, crucially, adds the error handling those copies lacked
+ * (a rejected fetch previously left the loader spinning forever).
+ *
+ * Pass a stable `queryFn` reference (e.g. an imported API function).
+ */
+export function useSanityQuery<T>(queryFn: () => Promise<T>): QueryState<T> {
+    const [state, setState] = useState<QueryState<T>>({
+        data: null,
+        loading: true,
+        error: null,
+    });
+
+    useEffect(() => {
+        let active = true;
+        setState({ data: null, loading: true, error: null });
+
+        queryFn()
+            .then((data) => {
+                if (active) {
+                    setState({ data, loading: false, error: null });
+                }
+            })
+            .catch((error: unknown) => {
+                if (active) {
+                    setState({
+                        data: null,
+                        loading: false,
+                        error: error instanceof Error ? error : new Error(String(error)),
+                    });
+                }
+            });
+
+        return () => {
+            active = false;
+        };
+    }, [queryFn]);
+
+    return state;
+}

--- a/react-frontend/src/index.tsx
+++ b/react-frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './styles/tokens.css';
 import './index.css';
 import App from './App';
 import { Analytics } from '@vercel/analytics/react';

--- a/react-frontend/src/react-app-env.d.ts
+++ b/react-frontend/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/react-frontend/src/styles/section.module.css
+++ b/react-frontend/src/styles/section.module.css
@@ -1,0 +1,7 @@
+.section {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 2rem;
+}

--- a/react-frontend/src/styles/surfaces.module.css
+++ b/react-frontend/src/styles/surfaces.module.css
@@ -1,0 +1,34 @@
+/* Shared surface treatments — replaces theme.container / theme.boxingStyle. */
+
+.container {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem;
+    place-items: stretch;
+    background-color: var(--color-base-50);
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.boxing {
+    border: var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.column {
+    flex-direction: column;
+}
+
+.center {
+    text-align: center;
+}
+
+/* Vertical stack used by container content groups (Education, Experience). */
+.stack {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+}

--- a/react-frontend/src/styles/tokens.css
+++ b/react-frontend/src/styles/tokens.css
@@ -1,0 +1,59 @@
+/**
+ * Design tokens — single source of truth for the portfolio's visual language.
+ *
+ * These CSS custom properties are consumed two ways:
+ *   1. Directly in *.module.css files via var(--token).
+ *   2. Through the TS theme (contexts/ThemeContext), which exposes the same
+ *      tokens as var() references so existing inline/emotion styles keep working.
+ *
+ * Color ramps generated from:
+ * https://accessiblepalette.com/?lightness=98.2,93.95,85.1,76.5,67.65,57,47,40.4,24,16
+ */
+
+:root {
+  /* Base (neutral) ramp */
+  --color-base-0: #ffffff;
+  --color-base-50: #fafaf6;
+  --color-base-100: #edeee6;
+  --color-base-200: #d4d5cd;
+  --color-base-300: #bdbdb6;
+  --color-base-400: #a5a59f;
+  --color-base-500: #898984;
+  --color-base-600: #6f706c;
+  --color-base-700: #545451;
+  --color-base-800: #393937;
+  --color-base-900: #282827;
+
+  /* Secondary (warm) ramp */
+  --color-secondary-0: #ffffff;
+  --color-secondary-50: #fef9f5;
+  --color-secondary-100: #fbebdd;
+  --color-secondary-200: #f8d7bc;
+  --color-secondary-300: #f6c29a;
+  --color-secondary-400: #d4986c;
+  --color-secondary-500: #b4805b;
+  --color-secondary-600: #93684b;
+  --color-secondary-700: #7c573f;
+  --color-secondary-800: #644633;
+  --color-secondary-900: #4a3326;
+
+  /* Radius */
+  --radius: 8px;
+
+  /* Elevation */
+  --shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+
+  /* Motion */
+  --transition: all 0.3s ease-out;
+
+  /* Borders */
+  --border: 1px solid var(--color-base-50);
+
+  /* Spacing scale (used by layout primitives and components) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
+  --space-6: 3rem;
+}

--- a/react-frontend/src/utils/cx.ts
+++ b/react-frontend/src/utils/cx.ts
@@ -1,0 +1,7 @@
+/**
+ * Minimal classnames helper — joins truthy class strings.
+ * Usage: cx(styles.icon, size === 'lg' && styles.lg, pointer && styles.pointer)
+ */
+export function cx(...classes: Array<string | false | null | undefined>): string {
+    return classes.filter(Boolean).join(' ');
+}

--- a/react-frontend/src/vite-env.d.ts
+++ b/react-frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/react-frontend/tsconfig.json
+++ b/react-frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": [
       "dom",
       "dom.iterable",
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/sanity-backend/.eslintrc
+++ b/sanity-backend/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "@sanity/eslint-config-studio"
-}

--- a/sanity-backend/eslint.config.mjs
+++ b/sanity-backend/eslint.config.mjs
@@ -1,0 +1,8 @@
+import studio from '@sanity/eslint-config-studio'
+
+export default [
+  {
+    ignores: ['dist', '.sanity', 'node_modules'],
+  },
+  ...studio,
+]

--- a/sanity-backend/package-lock.json
+++ b/sanity-backend/package-lock.json
@@ -9,31 +9,23 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/icons": "^2.6.0",
-        "@sanity/ui": "^3.2.0",
-        "@sanity/vision": "^6.2.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-icons": "^5.0.1",
-        "react-is": "^18.2.0",
-        "sanity": "^6.2.0",
-        "styled-components": "^6.0.7"
+        "@sanity/icons": "^3.7.7",
+        "@sanity/ui": "^3.3.0",
+        "@sanity/vision": "^6.3.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-icons": "^5.7.0",
+        "react-is": "^19.2.7",
+        "sanity": "^6.3.0",
+        "styled-components": "^6.4.3"
       },
       "devDependencies": {
-        "@sanity/eslint-config-studio": "^3.0.1",
-        "@types/react": "^18.0.25",
-        "eslint": "^8.6.0",
-        "prettier": "^3.0.2",
-        "typescript": "^5.1.6"
-      }
-    },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "@sanity/eslint-config-studio": "^6.0.0",
+        "@types/node": "^26.1.0",
+        "@types/react": "^19.2.17",
+        "eslint": "^9.39.4",
+        "prettier": "^3.9.4",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -154,9 +146,9 @@
       }
     },
     "node_modules/@architect/hydrate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-6.0.0.tgz",
-      "integrity": "sha512-bm4w/RAYqTLVDPgjfK/0835uh0AMEvFhUdno1YUnSo3paDbwU/oCi1XYtwgJ+ZbN34n5RHQt0up9Lv08BoF+Dw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-6.0.2.tgz",
+      "integrity": "sha512-7d3bFa7HsaspIRX5un37jWX1Kk3uWxBjGSIXfkNwPefHHvUVzrl3BypATjRVyocZ/iDbXWqJlZ+WKlAsgi14XA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@architect/inventory": "~6.0.0",
@@ -169,6 +161,18 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@architect/hydrate/node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/@architect/inventory": {
@@ -377,24 +381,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.15.tgz",
-      "integrity": "sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==",
-      "dev": true,
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -491,6 +477,27 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -781,6 +788,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -852,6 +860,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1841,6 +1850,7 @@
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -2014,9 +2024,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
-      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -2071,9 +2081,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.2.tgz",
-      "integrity": "sha512-8kU6WNRYBKV9Sw3cxNz+uSvUvx3tt+1qgupGFPubnbLFDHOgh5qQdIGmXcD7bkA/PROK6LDKVhKMpcY7H++Amg==",
+      "version": "6.43.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
+      "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.7.0",
@@ -2325,6 +2335,21 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -2743,15 +2768,19 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -2762,6 +2791,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2770,71 +2800,115 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -2892,18 +2966,42 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
+        "@humanfs/types": "^0.15.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2911,6 +3009,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -2919,11 +3018,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-      "dev": true
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
@@ -3342,7 +3449,8 @@
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@lezer/common": {
       "version": "1.5.2",
@@ -3380,9 +3488,9 @@
       }
     },
     "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
     "node_modules/@mdit/plugin-alert": {
@@ -3406,21 +3514,21 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.0.tgz",
-      "integrity": "sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.6.0.tgz",
+      "integrity": "sha512-0dMjLhU+2HNPyX5Txu6JqA2CAYxVLRv3c/bpRk58aNVwhDO/jqp66IdFztdMZ1XiHqOW9jB3pkOSuIpcl/yXpQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/managers": "2.5.0",
-        "@module-federation/sdk": "2.5.0",
-        "@module-federation/third-party-dts-extractor": "2.5.0",
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/managers": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
+        "@module-federation/third-party-dts-extractor": "2.6.0",
         "adm-zip": "0.5.10",
         "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
-        "undici": "7.24.7",
-        "ws": "8.18.0"
+        "undici": "7.28.0",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": "^4.9.0 || ^5.0.0",
@@ -3442,76 +3550,55 @@
       }
     },
     "node_modules/@module-federation/dts-plugin/node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
     },
-    "node_modules/@module-federation/dts-plugin/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
-      "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.6.0.tgz",
+      "integrity": "sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==",
       "license": "MIT"
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.0.tgz",
-      "integrity": "sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.6.0.tgz",
+      "integrity": "sha512-7Y4Ri6Lh10dCHoEJvNGFmK2Gg1JKy7oJ1TEZhuU3n3mgIpZ519fDNRvU4+tiO9C49p1xyK+mQ8ewxth83waKUA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.5.0",
+        "@module-federation/sdk": "2.6.0",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.0.tgz",
-      "integrity": "sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.6.0.tgz",
+      "integrity": "sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/runtime-core": "2.5.0",
-        "@module-federation/sdk": "2.5.0"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/runtime-core": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.0.tgz",
-      "integrity": "sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.6.0.tgz",
+      "integrity": "sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.0",
-        "@module-federation/sdk": "2.5.0"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
-      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.6.0.tgz",
+      "integrity": "sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==",
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^2.7.0 || ^3.3.2"
@@ -3523,9 +3610,9 @@
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.0.tgz",
-      "integrity": "sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.6.0.tgz",
+      "integrity": "sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -3550,17 +3637,17 @@
       }
     },
     "node_modules/@module-federation/vite": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.0.tgz",
-      "integrity": "sha512-xgEcAj00A+1fGNLOg88FbJJjyLGqQQMM4qvTEGgw1bkVT1l8Bv2hqhjfk0UNs86EPPYfBbZxC2dR2rLxIljMQw==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.11.tgz",
+      "integrity": "sha512-tmVBSdHDDQvGPYPZgp7Hpi980reReObP1yyai3kxWeQZ8CL6zAFIgz3wb97o20J/lJjxM6DDzs31da3RXtvdxA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.5.0",
-        "@module-federation/runtime": "2.5.0",
-        "@module-federation/sdk": "2.5.0",
-        "es-module-lexer": "^2.0.0",
-        "estree-walker": "^3.0.3",
-        "pathe": "^2.0.3"
+        "@module-federation/dts-plugin": "2.6.0",
+        "@module-federation/runtime": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3652,15 +3739,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
-    },
     "node_modules/@noble/ed25519": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
@@ -3686,6 +3764,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -3698,6 +3777,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -3706,6 +3786,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -3789,6 +3870,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@oclif/plugin-help": {
@@ -3918,9 +4014,9 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
@@ -3956,9 +4052,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -3997,6 +4093,30 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@portabletext/editor": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-7.9.0.tgz",
+      "integrity": "sha512-zF6a1SghGA0u7TN3rWaWYHEuQhZgY1YWgmcswbyLnrtNqvn59HvCMJlDUt+h4W+Z5cKsIVImfJhLyzG4YgOfZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/html": "^1.1.0",
+        "@portabletext/keyboard-shortcuts": "^2.1.3",
+        "@portabletext/markdown": "^1.4.2",
+        "@portabletext/patches": "^2.0.5",
+        "@portabletext/schema": "^2.2.2",
+        "@portabletext/to-html": "^5.0.2",
+        "@xstate/react": "^6.1.0",
+        "debug": "^4.4.3",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "xstate": "^5.32.2"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
       }
     },
     "node_modules/@portabletext/html": {
@@ -4048,6 +4168,125 @@
         "node": ">=20.19 <22 || >=22.12"
       }
     },
+    "node_modules/@portabletext/plugin-character-pair-decorator": {
+      "version": "8.0.26",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-8.0.26.tgz",
+      "integrity": "sha512-UaFRqWIpc1qhlVWdUoXdg3Ec3mLuKr3xnHh4tLF/FCrc47g9uDgtHLXRssFaUwVPK1v55pzHlMuVq8ugA79F4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@xstate/react": "^6.1.0",
+        "xstate": "^5.32.2"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-dnd": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-dnd/-/plugin-dnd-1.0.11.tgz",
+      "integrity": "sha512-Sg5vap7gJxD5uMyH77/K6LFj8s+ftxsqSN0+hSXR5FLYCgntduhsoT74cZGIVBGRNmJ9PX9d3Xuv7HNYL7KPXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-input-rule": {
+      "version": "5.0.26",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-5.0.26.tgz",
+      "integrity": "sha512-fnY0KkL6tTnTj9Ccsv4FJliFFlPrAyWUaSzuF5Gz6tNHDN8ixQbptfv3ZyNeu24OJEzbZwNW39fC9bz6sY4POw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xstate/react": "^6.1.0",
+        "xstate": "^5.32.2"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-list-index": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-list-index/-/plugin-list-index-1.0.11.tgz",
+      "integrity": "sha512-m2snUoINZxyvXiPawLwu+KzAvFqTPrjF2vKeKc0ciuBxS/hI+D8mQyMOQjBhuXgab+efQVzVGu6R6SwEgECatw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-markdown-shortcuts": {
+      "version": "8.0.26",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-8.0.26.tgz",
+      "integrity": "sha512-se+Xk5HZpupVWY938/ebGmcl5S2bd65w76EshGGrm2KH52snLggAiuSJEx0a1wGJdHEuRdOB8Uu7chADkfYK/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/plugin-character-pair-decorator": "^8.0.26",
+        "@portabletext/plugin-input-rule": "^5.0.26"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-one-line": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-7.0.26.tgz",
+      "integrity": "sha512-C1KEeDjq0JIGD1sUxbZjjgOm1zhX+cm4i8pwlZ34uF4LTGxOdw6xVWChUXAxb8p1i2iHBeIepTP2ldfMxkR9Qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-paste-link": {
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-paste-link/-/plugin-paste-link-4.0.26.tgz",
+      "integrity": "sha512-9Qgq9MUrmjkufk9smlXFGvRIS3bP9jkpEA/oZOZCuJYY6yVnBDxkPnRtuwcTd/B1u9FNHANDjlEdmLoKFzb5lA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@portabletext/plugin-typography": {
+      "version": "8.0.26",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-8.0.26.tgz",
+      "integrity": "sha512-DqrI59PRBCNioIVUuxaoJkZUCPwkMfnmIWslx5U9ab3LwaTBH1KkWTT1mdKnmXnTTP6SMaa4OG55T/cTqGxxag==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/plugin-input-rule": "^5.0.26"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^7.9.0",
+        "react": "^19.2"
+      }
+    },
     "node_modules/@portabletext/react": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-6.2.0.tgz",
@@ -4076,29 +4315,6 @@
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
-      }
-    },
-    "node_modules/@portabletext/sanity-bridge/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@portabletext/sanity-bridge/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@portabletext/schema": {
@@ -4157,10 +4373,20 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@rexxars/react-split-pane": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rexxars/react-split-pane/-/react-split-pane-1.0.0.tgz",
+      "integrity": "sha512-Ewl8ugA2VQd+idzcg65WFbYh/oCLPOFjeDKpebexPgFDDX8ZwsHZWy5jNwiIWI8txDidVmRP98lsnmBHlIywWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -4174,9 +4400,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -4190,9 +4416,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -4206,9 +4432,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -4222,9 +4448,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -4238,9 +4464,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -4257,9 +4483,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -4276,9 +4502,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -4295,9 +4521,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -4314,9 +4540,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -4333,9 +4559,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -4352,9 +4578,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -4368,9 +4594,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -4386,9 +4612,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -4402,9 +4628,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -4422,12 +4648,6 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
-    },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz",
-      "integrity": "sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==",
-      "dev": true
     },
     "node_modules/@sanity-labs/design-tokens": {
       "version": "0.0.2-alpha.4",
@@ -4479,16 +4699,16 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-7.4.0.tgz",
-      "integrity": "sha512-vXRJefA9NYkEej99O3k3O2Eqr4Lj+74OBtRNGqczYz1p7I4ei7O33Wp7JIcJII6gWhcijy32zMBJFv+kS/xMww==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-7.5.0.tgz",
+      "integrity": "sha512-CDlE7xtfQ0tpfu3PzY2jrHd8Oe4QUdbTZofKYKvmjcu3jMlpnTFHhWOn4O5NLMmW2lqLeDOii01IEMl7DliYzQ==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.11.7",
         "@oclif/plugin-help": "^6.2.52",
         "@oclif/plugin-not-found": "^3.2.87",
-        "@sanity/cli-build": "^1.1.1",
-        "@sanity/cli-core": "^2.1.1",
+        "@sanity/cli-build": "^2.0.1",
+        "@sanity/cli-core": "^2.1.3",
         "@sanity/client": "^7.23.0",
         "@sanity/codegen": "^7.0.3",
         "@sanity/descriptors": "^1.3.0",
@@ -4502,10 +4722,9 @@
         "@sanity/telemetry": "^1.1.0",
         "@sanity/template-validator": "^3.1.0",
         "@sanity/types": "^6.1.0",
-        "@sanity/workbench-cli": "^1.1.0",
+        "@sanity/workbench-cli": "^1.1.3",
         "@sanity/worker-channels": "^2.0.0",
         "@vercel/frameworks": "3.29.0",
-        "@vitejs/plugin-react": "^6.0.3",
         "chokidar": "^5.0.0",
         "console-table-printer": "^2.15.0",
         "date-fns": "^4.4.0",
@@ -4547,7 +4766,7 @@
         "tinyglobby": "^0.2.17",
         "tsx": "^4.22.4",
         "typeid-js": "^1.2.0",
-        "vite": "^8.1.0",
+        "vite": "^8.1.2",
         "which": "^6.0.1",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
@@ -4568,19 +4787,19 @@
       }
     },
     "node_modules/@sanity/cli-build": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli-build/-/cli-build-1.1.1.tgz",
-      "integrity": "sha512-CqFWTcgPLt1vKBR4b3L7n0ftkx5KuykNg0A3Wm+DSoY8JJj3wr/zhLJ0GGUUGeSdK1L+uEdmCczXRI+CvULVDg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli-build/-/cli-build-2.0.1.tgz",
+      "integrity": "sha512-xJTq1Lh/bajbMzNdu6PBYgSbBoWBnXRw5svggcQ6eNI7crT8Ytz5Kfp4aPKND9JH3KekOwduBt7CF5yyTNN1zw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.11.7",
         "@rolldown/plugin-babel": "^0.2.3",
-        "@sanity/cli-core": "^2.1.1",
+        "@sanity/cli-core": "^2.1.3",
         "@sanity/generate-help-url": "^4.0.0",
         "@sanity/schema": "^6.1.0",
         "@sanity/telemetry": "^1.1.0",
         "@sanity/types": "^6.1.0",
-        "@sanity/workbench-cli": "^1.1.0",
+        "@sanity/workbench-cli": "^1.1.3",
         "@vitejs/plugin-react": "^6.0.3",
         "chokidar": "^5.0.0",
         "cjs-module-lexer": "^2.2.0",
@@ -4593,7 +4812,7 @@
         "react-dom": "^19.2.7",
         "read-package-up": "^12.0.0",
         "semver": "^7.8.1",
-        "vite": "^8.1.0",
+        "vite": "^8.1.2",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -4638,29 +4857,6 @@
         }
       }
     },
-    "node_modules/@sanity/cli-build/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/cli-build/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@sanity/cli-build/node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -4686,45 +4882,6 @@
         }
       }
     },
-    "node_modules/@sanity/cli-build/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@sanity/cli-build/node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@sanity/cli-build/node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/@sanity/cli-build/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
     "node_modules/@sanity/cli-build/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -4738,9 +4895,9 @@
       }
     },
     "node_modules/@sanity/cli-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli-core/-/cli-core-2.1.1.tgz",
-      "integrity": "sha512-UNDsUCYXmzGzxFeG37E9c0i5aDZBuLJtbg7Uwjt8GdYjotHxk8NX4t+gx76PDH3bQc0+kvzkwRiGiOAXK2r0/w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sanity/cli-core/-/cli-core-2.1.3.tgz",
+      "integrity": "sha512-rGNGUbQLgYPlrzbaWmrl9XGmkRtYn6GXyAH2r33svLSpBoldBpoDXEt4KrI0QGmJWWIUNZalUySgLH4snXRWDA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",
@@ -4759,7 +4916,7 @@
         "read-package-up": "^12.0.0",
         "rxjs": "^7.8.2",
         "tsx": "^4.22.4",
-        "vite": "^8.1.0",
+        "vite": "^8.1.2",
         "vite-node": "^6.0.0",
         "zod": "^4.4.3"
       },
@@ -5112,54 +5269,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@sanity/cli/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/@vitejs/plugin-react": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rolldown/pluginutils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "vite": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rolldown/plugin-babel": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@sanity/cli/node_modules/isexe": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
@@ -5168,51 +5277,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/@sanity/cli/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
-    },
-    "node_modules/@sanity/cli/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     },
     "node_modules/@sanity/cli/node_modules/semver": {
       "version": "7.8.5",
@@ -5352,6 +5416,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@sanity/codegen/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@sanity/codegen/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5413,9 +5489,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-6.2.0.tgz",
-      "integrity": "sha512-TDa3R8GWWr3C2o+HfFm84p8fs71G8jk1YhLFyAcToksF7fhYeqpmCvuqgQhl3xUCR82t2frDisY54Ow9nfpEfg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-6.3.0.tgz",
+      "integrity": "sha512-PJ3MYRY0bOtyZGA2otlvdqFWIYKQF+jJ6EYgFAmxRhTyIMN4wnL7w7wbZsQVmqdKsbks8ZcaU/CJfBH9LQpjDA==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0"
@@ -5446,22 +5522,22 @@
       }
     },
     "node_modules/@sanity/eslint-config-studio": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/eslint-config-studio/-/eslint-config-studio-3.0.1.tgz",
-      "integrity": "sha512-N7IFd/VZuL0UyJ2T5t5WWWf9DrhgY6lt0bnnScwwyX4ijA7WMFtxR5rgL2EDGdhI2eYyxOeleeBaK9QEXgiA1A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/eslint-config-studio/-/eslint-config-studio-6.0.0.tgz",
+      "integrity": "sha512-IfIItATVN5QhlwA3mWGBnWIHpfnQSa1XuTL1BOIZdzkcg02AAWjHcU40Z9WrWWCll1yPbmmAWvmSU4PX9DsBTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.22.8",
-        "@babel/eslint-parser": "^7.22.7",
-        "@babel/preset-env": "^7.22.7",
-        "@babel/preset-react": "^7.22.5",
-        "@rushstack/eslint-patch": "^1.3.2",
-        "@typescript-eslint/eslint-plugin": "^6.2.1",
-        "@typescript-eslint/parser": "^6.2.1",
-        "confusing-browser-globals": "^1.0.11",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.32.2",
-        "eslint-plugin-react-hooks": "^4.6.0"
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "typescript-eslint": "^8.50.1"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0"
       }
     },
     "node_modules/@sanity/eventsource": {
@@ -5512,14 +5588,15 @@
       "license": "MIT"
     },
     "node_modules/@sanity/icons": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.7.0.tgz",
-      "integrity": "sha512-vW/G8CB3+R1gww8C8ZjNchhpXrXSDLIJ0KnWy9iDlSWaFEnUrbi18yzCCrHRMFzXTPl2QtqZhjtE+A5Gyhf2QA==",
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.7.7.tgz",
+      "integrity": "sha512-55DgVXOgXxjyYT+bEcubxxToj2uvk2qbBKG6PtLMGYuaf5lWzN9JCPfWV1sbvypShvbVZivXs14vsk0ajW9BVg==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": "^18"
+        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/@sanity/id-utils": {
@@ -5571,6 +5648,25 @@
         "@sanity/client": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@sanity/insert-menu": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-3.0.8.tgz",
+      "integrity": "sha512-O3g3ZpvRYLw4VBly4fKUzEK+2Mze8iBZfLpRjh8BgjLWSZ/9XCwrRUMJvKZ6z9qQI8zHRqwZQNslgEjETTTZ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^3.7.4",
+        "@sanity/ui": "^3.2.0",
+        "lodash-es": "^4.18.1",
+        "react-is": "^19.2.6"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@sanity/types": "*",
+        "react": "^19.2"
+      }
+    },
     "node_modules/@sanity/json-match": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@sanity/json-match/-/json-match-1.0.5.tgz",
@@ -5590,6 +5686,21 @@
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@sanity/logos": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.2.2.tgz",
+      "integrity": "sha512-KIWFL7nYEOINXIzaTF9aVhd481hFF/ak+SRnpgksYuJXlo2hbY/UoEJBz6KhsEP5dfO/NwqG82QrkwzLvd6izA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/color": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/@sanity/media-library-types": {
@@ -5635,29 +5746,6 @@
         "@sanity/cli-core": "^2"
       }
     },
-    "node_modules/@sanity/migrate/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/migrate/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@sanity/mutate": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.18.1.tgz",
@@ -5693,39 +5781,16 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-6.2.0.tgz",
-      "integrity": "sha512-eeObdjhSOc4d3hP6oveDiXcnR5TXxlqQDYcjdIp/UcNrPAmCkXHFxHzicmbrWY0WbNY3uBqmyWG1jAgy53JyNg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-6.3.0.tgz",
+      "integrity": "sha512-Rfwx+U1lxzjSecZ9k41rjCa8KTwv9H9PMLhxw/sojAG+kbEfo0TwFjM9BqxVq2Cu9+U02DoE4c4tv6zXqQMqIQ==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
-        "@sanity/types": "6.2.0",
+        "@sanity/types": "6.3.0",
         "@sanity/uuid": "^3.0.3",
         "debug": "^4.4.3",
         "lodash-es": "^4.18.1"
-      }
-    },
-    "node_modules/@sanity/mutator/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/mutator/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@sanity/presentation-comlink": {
@@ -5739,24 +5804,6 @@
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
-      }
-    },
-    "node_modules/@sanity/presentation-comlink/node_modules/@sanity/visual-editing-types": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.8.tgz",
-      "integrity": "sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@sanity/client": "^7.11.2",
-        "@sanity/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@sanity/types": {
-          "optional": true
-        }
       }
     },
     "node_modules/@sanity/preview-url-secret": {
@@ -5784,16 +5831,6 @@
         "uuid": "^8.0.0"
       }
     },
-    "node_modules/@sanity/preview-url-secret/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@sanity/prism-groq": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sanity/prism-groq/-/prism-groq-1.1.2.tgz",
@@ -5809,12 +5846,12 @@
       }
     },
     "node_modules/@sanity/runtime-cli": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-17.0.0.tgz",
-      "integrity": "sha512-T/HVsnNSDvzZFQeqYe0FpSiH6LwXR/zMPU5vYVfNLsLwoRUxyB8kublQdLNk5i6z6iocyr/fZVY14TZD7NznWQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-17.1.0.tgz",
+      "integrity": "sha512-2Se6htjIs+/oLzoN7uI191sO4w0OySP8nCGiX6YxN0j2j74LR9EKPb21+Qqu7Vup1c8hiaggUXR+xmaCFQ7m6g==",
       "license": "MIT",
       "dependencies": {
-        "@architect/hydrate": "~6.0.0",
+        "@architect/hydrate": "~6.0.2",
         "@architect/inventory": "~6.0.0",
         "@inquirer/prompts": "^8.5.2",
         "@oclif/core": "^4.11.6",
@@ -6182,43 +6219,20 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-6.2.0.tgz",
-      "integrity": "sha512-6o81OxTYuMre8FnImtHUtiE2i57O/S6NNaaF56MWwc2tsIO/6QBMz/2bu52DFrcRfLd6CMGfuapjBavJYfifNw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-6.3.0.tgz",
+      "integrity": "sha512-2Bud3VCBSiS0B4KwHlCx4jYUAWX3OWVByq+JwnfCKrDWGFgxRohrmS0Lx8G9fjbUJ4fUX868HFEdyTt1METW7w==",
       "license": "MIT",
       "dependencies": {
         "@sanity/descriptors": "^1.3.0",
         "@sanity/generate-help-url": "^4.0.0",
-        "@sanity/types": "6.2.0",
+        "@sanity/types": "6.3.0",
         "arrify": "^3.0.0",
-        "groq-js": "^1.30.2",
+        "groq-js": "^1.30.3",
         "humanize-list": "^1.0.1",
         "leven": "^4.1.0",
         "lodash-es": "^4.18.1",
         "object-inspect": "^1.13.4"
-      }
-    },
-    "node_modules/@sanity/schema/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/schema/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@sanity/schema/node_modules/arrify": {
@@ -6268,29 +6282,6 @@
       },
       "engines": {
         "node": ">=18.2"
-      }
-    },
-    "node_modules/@sanity/sdk/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/sdk/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@sanity/sdk/node_modules/groq": {
@@ -6360,10 +6351,23 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@sanity/types": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.3.0.tgz",
+      "integrity": "sha512-IMll1cRPr8DGHEwiOoYiGIvRCA4i0ug25V5tzrCBeWhvJPX9vr4vA7jTHf6dEzvSZW9q6Fo/0X/9aBS42IOrxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^7.23.0",
+        "@sanity/media-library-types": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@sanity/ui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.2.0.tgz",
-      "integrity": "sha512-bWi2zz8ixZcGHh1YXsgliHRaA9Vw11V5lkJN6SGZcuvbrwPFm6j71Cc3jL1l2MQ11I0HmUYmQ5E76+cT4SznYA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.3.0.tgz",
+      "integrity": "sha512-jjIqfusBeYtyuHkW56M0WH9gsprSw3eOnxq+IGSp2/3zpqQR2mOEN9lHVlmaPmqz8vugkDAojPNZFR83wCm0yw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
@@ -6386,65 +6390,21 @@
         "styled-components": "^5.2 || ^6"
       }
     },
-    "node_modules/@sanity/ui/node_modules/@sanity/icons": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.7.4.tgz",
-      "integrity": "sha512-O9MnckiDsphFwlRS8Q3kj3n+JYUZ0UzKRujnSikMZOKI0dayucRe4U2XvxikRhJnFhcEJXW2RkWJoBaCoup9Sw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@sanity/ui/node_modules/use-effect-event": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.3.tgz",
-      "integrity": "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
-      }
-    },
     "node_modules/@sanity/util": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-6.2.0.tgz",
-      "integrity": "sha512-bdFOc2MSVuVhPhtDof0Pj4xs+GZbWPfGivrKs7qKk32OIXXc5e+XA0zgUhwGTxbw5xnca2Y4fAOja+LlxzkIlg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-6.3.0.tgz",
+      "integrity": "sha512-VUA3Mzf3xiO4Zyhe2bXbYQYbK2SLdayn5ubQyu1a+DMbABe9eAWA1/CpapFYEgoJR3I2YED8owoQJid2yx70vg==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.5.0",
         "@date-fns/utc": "^2.1.1",
         "@sanity/client": "^7.23.0",
-        "@sanity/types": "6.2.0",
+        "@sanity/types": "6.3.0",
         "date-fns": "^4.4.0",
         "rxjs": "^7.8.2"
       },
       "engines": {
         "node": ">=22.12"
-      }
-    },
-    "node_modules/@sanity/util/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/@sanity/util/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@sanity/uuid": {
@@ -6457,9 +6417,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-6.2.0.tgz",
-      "integrity": "sha512-stTRxGILF7+eo2+3vkyOlGgHnuf3trM0AVBXsCVDl2UkmRhUOT0EE+zZpYWeOhgdvwgURrXQxv+g5LNTk1J9QQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-6.3.0.tgz",
+      "integrity": "sha512-MVeFvY2O5nSMO7xaL60JJS4rdXY7t41j0EKsFKKKlvceJCRfpp1st9gU7s9cX8yjVfP4Gd67JtqgMplWsbmqog==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
@@ -6478,6 +6438,7 @@
         "@sanity/ui": "^3.2.0",
         "@sanity/uuid": "^3.0.3",
         "@uiw/react-codemirror": "^4.25.10",
+        "@vanilla-extract/dynamic": "^2.1.5",
         "is-hotkey-esm": "^1.0.0",
         "json-2-csv": "^5.5.9",
         "json5": "^2.2.3",
@@ -6488,95 +6449,66 @@
       },
       "peerDependencies": {
         "react": "^19.2.2",
-        "sanity": "^6.0.0-0",
-        "styled-components": "^6.1.15"
+        "sanity": "^6.0.0-0"
       }
     },
-    "node_modules/@sanity/vision/node_modules/@rexxars/react-split-pane": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rexxars/react-split-pane/-/react-split-pane-1.0.0.tgz",
-      "integrity": "sha512-Ewl8ugA2VQd+idzcg65WFbYh/oCLPOFjeDKpebexPgFDDX8ZwsHZWy5jNwiIWI8txDidVmRP98lsnmBHlIywWA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/@sanity/icons": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.7.4.tgz",
-      "integrity": "sha512-O9MnckiDsphFwlRS8Q3kj3n+JYUZ0UzKRujnSikMZOKI0dayucRe4U2XvxikRhJnFhcEJXW2RkWJoBaCoup9Sw==",
+    "node_modules/@sanity/visual-editing-types": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.8.tgz",
+      "integrity": "sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/@uiw/react-codemirror": {
-      "version": "4.25.10",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.10.tgz",
-      "integrity": "sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@codemirror/commands": "^6.1.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.25.10",
-        "codemirror": "^6.0.0"
+        "@sanity/client": "^7.11.2",
+        "@sanity/types": "*"
       },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@babel/runtime": ">=7.11.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/theme-one-dark": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0",
-        "codemirror": ">=6.0.0",
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/react-rx": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.2.2.tgz",
-      "integrity": "sha512-L0M51QxRnb5RndopV3lGPtG+O2rGVZl6aIzH1Fyx5ieOog/E947Xu00JERxksPJ9Lxn7kdME2wFtsWpiKTgI+A==",
-      "license": "MIT",
-      "dependencies": {
-        "observable-callback": "^1.0.3",
-        "react-compiler-runtime": "1.0.0",
-        "use-effect-event": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": "^18.3 || >=19.0.0-0",
-        "rxjs": "^7"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/use-effect-event": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.3.tgz",
-      "integrity": "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
+      "peerDependenciesMeta": {
+        "@sanity/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sanity/workbench-cli": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@sanity/workbench-cli/-/workbench-cli-1.1.0.tgz",
-      "integrity": "sha512-wFV82o6Qd3OMyRoYN471qrq96ourIwP/5OeVfRRvDg9/FKu+CreuNhr8H7/7M9qg2lIUVe43Ia3Kmk6+E9S9/A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@sanity/workbench-cli/-/workbench-cli-1.1.3.tgz",
+      "integrity": "sha512-LsQG4/6MrUlanNM+/pjFP9e7KMbSzQGTavegrCxH6E2TbIZL+DtSESiMMvVyC933XHeU2zN0UpOIPwgAwT6sYA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/vite": "1.16.0",
-        "@sanity/cli-core": "^2.1.0",
-        "vite": "^8.0.16",
+        "@module-federation/vite": "1.16.11",
+        "@sanity/cli-core": "^2.1.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "vite": "^8.1.2",
         "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.12"
+      }
+    },
+    "node_modules/@sanity/workbench-cli/node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sanity/worker-channels": {
@@ -6595,62 +6527,62 @@
       "license": "MIT"
     },
     "node_modules/@sentry/browser": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.62.0.tgz",
-      "integrity": "sha512-uJi0yPssB3Nt/cZ8/S8opW42gaM59/6IyNtPFYD7C0ciudi/nIo5QMVpCYBBI3jnKFOIQLlsMT4pDlOLuxxNuQ==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.63.0.tgz",
+      "integrity": "sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.62.0",
-        "@sentry/core": "10.62.0",
-        "@sentry/feedback": "10.62.0",
-        "@sentry/replay": "10.62.0",
-        "@sentry/replay-canvas": "10.62.0"
+        "@sentry/browser-utils": "10.63.0",
+        "@sentry/core": "10.63.0",
+        "@sentry/feedback": "10.63.0",
+        "@sentry/replay": "10.63.0",
+        "@sentry/replay-canvas": "10.63.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.62.0.tgz",
-      "integrity": "sha512-mS9HVVuWIdye9o0xUGFmzNOBqktF4n5kugrF8NCOYYDrr5ZV8Cx7BlquHQn5UpCeViVhZtcDlEm4iOK7++Px7A==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.63.0.tgz",
+      "integrity": "sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.62.0"
+        "@sentry/core": "10.63.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.62.0.tgz",
-      "integrity": "sha512-tV69fMg2sS5DUFmQSnS7Jd5qJAp0izxwcsvBVz2ieTM9VMRi99IfOSYW9UYr3p1yfuksk41kefN5PEbeedUE+A==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.63.0.tgz",
+      "integrity": "sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.62.0.tgz",
-      "integrity": "sha512-d0BVjJVny6qpBgGJgWL0fbcoQHjtD3z3R8EK/KzTS3RO92JX5n3A536n5D/rh0gZFgcIwiUzBXegmyPOSQn9ng==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.63.0.tgz",
+      "integrity": "sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.62.0"
+        "@sentry/core": "10.63.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.62.0.tgz",
-      "integrity": "sha512-PChimVpY0wzs3H/hJqyl87/ITTHwIZWTSY68QoENZyLnp7DvLcFiZYub/gFws1pzDPhtIQXVLU72fbmUjT5PSg==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.63.0.tgz",
+      "integrity": "sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.62.0",
-        "@sentry/core": "10.62.0"
+        "@sentry/browser": "10.63.0",
+        "@sentry/core": "10.63.0"
       },
       "engines": {
         "node": ">=18"
@@ -6660,26 +6592,26 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.62.0.tgz",
-      "integrity": "sha512-rWp4hBhZOmdQhisxcKzAwTGiRk/LvWnNaElWe7nbRhjsM/usp2095yfjq4iJ47v9MtO7xxY6eUz++fLBycqXKg==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.63.0.tgz",
+      "integrity": "sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.62.0",
-        "@sentry/core": "10.62.0"
+        "@sentry/browser-utils": "10.63.0",
+        "@sentry/core": "10.63.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.62.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.62.0.tgz",
-      "integrity": "sha512-CzPAxmpe5US/ABGA1TzpjFKOFZN5uqlzrRh/uM9/daVuzLVKIAQ0XRNxo/PPEXvlDm/PoMdI5L0qIODuIKnyyw==",
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.63.0.tgz",
+      "integrity": "sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.62.0",
-        "@sentry/replay": "10.62.0"
+        "@sentry/core": "10.63.0",
+        "@sentry/replay": "10.63.0"
       },
       "engines": {
         "node": ">=18"
@@ -6718,12 +6650,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.4.tgz",
-      "integrity": "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==",
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.2"
+        "@tanstack/virtual-core": "3.17.3"
       },
       "funding": {
         "type": "github",
@@ -6748,9 +6680,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.2.tgz",
-      "integrity": "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6771,6 +6703,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/event-source-polyfill": {
@@ -6795,10 +6728,11 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
-      "dev": true
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -6822,6 +6756,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -6834,34 +6778,14 @@
       "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-      "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==",
-      "devOptional": true
-    },
     "node_modules/@types/react": {
-      "version": "18.2.34",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.34.tgz",
-      "integrity": "sha512-U6eW/alrRk37FU/MS2RYMjx0Va2JGIVXELTODaTIYgvWGCV4Y4TfTUzG8DdmpDNIT0Xpj/R7GfyHOJJrDttcvg==",
-      "devOptional": true,
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
-      "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==",
-      "devOptional": true
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
-      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -6883,152 +6807,159 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
-      "integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.9.1",
-        "@typescript-eslint/type-utils": "6.9.1",
-        "@typescript-eslint/utils": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">= 4"
       }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
-      "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.9.1",
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/typescript-estree": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
-      "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
-      "integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.9.1",
-        "@typescript-eslint/utils": "6.9.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
-      "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7036,110 +6967,78 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
-      "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
-      "integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.9.1",
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/typescript-estree": "6.9.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "brace-expansion": "^5.0.5"
       },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7147,23 +7046,42 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
-      "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "eslint-visitor-keys": "^3.4.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7171,12 +7089,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -7209,11 +7128,46 @@
         "@codemirror/view": ">=6.0.0"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.10.tgz",
+      "integrity": "sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.10",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@vanilla-extract/dynamic": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/dynamic/-/dynamic-2.1.5.tgz",
+      "integrity": "sha512-QGIFGb1qyXQkbzx6X6i3+3LMc/iv/ZMBttMBL+Wm/DetQd36KsKsFg5CtH3qy+1hCA/5w93mEIIAiL4fkM8ycw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vanilla-extract/private": "^1.0.9"
+      }
+    },
+    "node_modules/@vanilla-extract/private": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.9.tgz",
+      "integrity": "sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==",
+      "license": "MIT"
     },
     "node_modules/@vercel/error-utils": {
       "version": "2.2.0",
@@ -7242,9 +7196,9 @@
       }
     },
     "node_modules/@vercel/frameworks/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7255,9 +7209,9 @@
       }
     },
     "node_modules/@vercel/frameworks/node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -7308,6 +7262,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -7396,6 +7351,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7443,44 +7399,66 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
-      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-string": "^1.0.7"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7499,20 +7477,43 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7522,15 +7523,16 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7540,31 +7542,36 @@
       }
     },
     "node_modules/array.prototype.tosorted": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz",
-      "integrity": "sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-array-buffer": "^3.0.2",
-        "is-shared-array-buffer": "^1.0.2"
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7586,7 +7593,8 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -7594,13 +7602,14 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
-    "node_modules/asynciterator.prototype": {
+    "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
-      "integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/asynckit": {
@@ -7632,21 +7641,37 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
-      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -7691,7 +7716,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/bare-events": {
       "version": "2.9.1",
@@ -7776,20 +7802,6 @@
         }
       }
     },
-    "node_modules/bare-stream/node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/bare-url": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
@@ -7800,9 +7812,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7888,6 +7900,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/boxen/node_modules/emoji-regex": {
@@ -8119,6 +8143,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8139,14 +8164,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8195,12 +8221,17 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -8432,7 +8463,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -8449,12 +8481,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
-    },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-      "dev": true
     },
     "node_modules/console-table-printer": {
       "version": "2.16.1",
@@ -8481,7 +8507,8 @@
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -8503,9 +8530,9 @@
       "license": "MIT"
     },
     "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cron-parser": {
@@ -8538,6 +8565,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
@@ -8562,6 +8590,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -8633,7 +8662,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -8646,6 +8676,60 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dataloader": {
@@ -8734,7 +8818,8 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -8798,6 +8883,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -8823,7 +8909,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8847,6 +8933,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -8864,15 +8951,16 @@
       }
     },
     "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -8993,16 +9081,17 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.378",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
-      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+      "version": "1.5.383",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
+      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/empathic": {
       "version": "2.0.1",
@@ -9035,50 +9124,85 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
-      "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.2",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.5",
-        "es-set-tostringtag": "^2.0.1",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.2",
-        "get-symbol-description": "^1.0.0",
-        "globalthis": "^1.0.3",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.12",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "safe-array-concat": "^1.0.1",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.8",
-        "string.prototype.trimend": "^1.0.7",
-        "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.0",
-        "typed-array-byte-length": "^1.0.0",
-        "typed-array-byte-offset": "^1.0.0",
-        "typed-array-length": "^1.0.4",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.13"
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9106,25 +9230,31 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
-      "integrity": "sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "asynciterator.prototype": "^1.0.0",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.1",
-        "es-set-tostringtag": "^2.0.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.5",
-        "iterator.prototype": "^1.1.2",
-        "safe-array-concat": "^1.0.1"
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -9161,23 +9291,31 @@
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9249,299 +9387,191 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
-      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "aria-query": "^5.3.0",
-        "array-includes": "^3.1.7",
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
         "array.prototype.flatmap": "^1.3.2",
         "ast-types-flow": "^0.0.8",
-        "axe-core": "=4.7.0",
-        "axobject-query": "^3.2.1",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
-        "es-iterator-helpers": "^1.0.15",
-        "hasown": "^2.0.0",
+        "hasown": "^2.0.2",
         "jsx-ast-utils": "^3.3.5",
         "language-tags": "^1.0.9",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.7",
-        "object.fromentries": "^2.0.7"
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
       },
       "engines": {
         "node": ">=4.0"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.33.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
-      "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "array.prototype.tosorted": "^1.1.1",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.0.12",
+        "es-iterator-helpers": "^1.2.1",
         "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "object.hasown": "^1.1.2",
-        "object.values": "^1.1.6",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.4",
+        "resolve": "^2.0.0-next.5",
         "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.8"
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-scope/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -9561,9 +9591,10 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -9577,6 +9608,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -9588,23 +9620,16 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9698,7 +9723,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -9707,15 +9733,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -9725,6 +9752,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9736,13 +9764,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -9778,11 +9808,29 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/figures": {
@@ -9801,15 +9849,16 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/filelist": {
@@ -9897,6 +9946,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -9921,17 +9971,17 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -10006,11 +10056,32 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -10030,20 +10101,27 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10057,14 +10135,26 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -10186,13 +10276,15 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10213,31 +10305,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -10308,13 +10381,28 @@
         "which": "bin/which"
       }
     },
-    "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10327,6 +10415,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -10360,16 +10449,10 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
-    },
     "node_modules/groq": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-6.2.0.tgz",
-      "integrity": "sha512-gg3ztgTGPVz7XSiGEUmzt20hkr9BQk0nObC2jOJTv61ejPcFTo5z79R2xfv6AltT5PwGsKfAbOdnKIVZc9YsHg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-6.3.0.tgz",
+      "integrity": "sha512-5IdTNLvtwbsP4ZjzxzAx1tMaX6iIiVpYJVeWYUEFWJveRGcLzitDpaHSmGs7XYUsDty7QxqJwE7LLa1WHAhyQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.12"
@@ -10415,10 +10498,14 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10445,10 +10532,14 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10532,6 +10623,23 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/history": {
@@ -10651,9 +10759,9 @@
       "license": "MIT"
     },
     "node_modules/i18next": {
-      "version": "26.3.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.3.tgz",
-      "integrity": "sha512-aYVegyBdXSO93CMMihvr47jI7GHSOcIahMpJX+qzUXDzW4xDJf2uenIA+45vDU+YhiVdcfsql70AC9RVdMNrHg==",
+      "version": "26.3.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.4.tgz",
+      "integrity": "sha512-pa7m0d7pBDqGHZxljT+WPFeyFgQ7P7SciPPo1tTqYuO0z4sqADYhwnBESmmGp/wEof1inwdls/k8ZgTg8rxFHA==",
       "funding": [
         {
           "type": "individual",
@@ -10695,18 +10803,20 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -10733,6 +10843,7 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -10758,20 +10869,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "4.1.1",
@@ -10783,14 +10885,15 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
-      "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.2",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10821,26 +10924,35 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10850,12 +10962,16 @@
       }
     },
     "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-bigints": "^1.0.1"
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10874,13 +10990,14 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10894,6 +11011,7 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -10916,13 +11034,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10962,21 +11100,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-finalizationregistry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
-      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10992,12 +11151,17 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11010,6 +11174,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -11103,18 +11268,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-installed-globally/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -11128,19 +11281,24 @@
       }
     },
     "node_modules/is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -11158,12 +11316,14 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11173,12 +11333,15 @@
       }
     },
     "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -11212,13 +11375,16 @@
       "license": "MIT"
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11240,21 +11406,29 @@
       }
     },
     "node_modules/is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11273,12 +11447,14 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11288,12 +11464,15 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11331,34 +11510,46 @@
       }
     },
     "node_modules/is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11388,12 +11579,14 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -11498,16 +11691,21 @@
       }
     },
     "node_modules/iterator.prototype": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
-      "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.2.1",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "reflect.getprototypeof": "^1.0.4",
-        "set-function-name": "^2.0.1"
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/jake": {
@@ -11539,7 +11737,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -11651,7 +11850,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-lexer": {
       "version": "1.2.0",
@@ -11669,7 +11869,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
       "version": "1.3.0",
@@ -11694,7 +11895,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stream-stringify": {
       "version": "3.1.7",
@@ -11715,6 +11917,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -11742,6 +11945,7 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -11757,6 +11961,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -11780,16 +11985,18 @@
       }
     },
     "node_modules/language-subtag-registry": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
-      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
-      "dev": true
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "language-subtag-registry": "^0.3.20"
       },
@@ -11814,6 +12021,7 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -12119,6 +12327,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -12157,7 +12366,8 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "7.0.1",
@@ -12185,6 +12395,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -12196,6 +12407,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -12312,6 +12524,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -12327,6 +12540,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -12422,12 +12647,12 @@
       }
     },
     "node_modules/motion": {
-      "version": "12.41.0",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.41.0.tgz",
-      "integrity": "sha512-avEDKE22rFPJqDr3Ttk7gMQpeaOmNik60NoJ5T0tj+RBCNvz21D3ArY3l4uitoeQ7eIpDqueWaO3pPYFv8JOVA==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.41.0",
+        "framer-motion": "^12.42.2",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -12448,9 +12673,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.41.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.41.0.tgz",
-      "integrity": "sha512-Lk3J39fOGg6xNr1KRZsN6usDyBf8aP7MEbUPez1VCughHt79OrP7VGqNrPyFL0riaT7WS8t9DRw1M3BHtM/xKw==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"
@@ -12461,33 +12686,6 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
       "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
-    },
-    "node_modules/motion/node_modules/framer-motion": {
-      "version": "12.41.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.41.0.tgz",
-      "integrity": "sha512-OHAMNiCEON1RDBlRGuulsN5AD8ptMjvk5QWfFmYmBLPZ3zFGIJe60kQucQQf4cez1OzQmjYBWDY+dYfISkUdqg==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.41.0",
-        "motion-utils": "^12.39.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12541,7 +12739,27 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/node-html-parser": {
       "version": "7.1.0",
@@ -12554,9 +12772,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
-      "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12655,6 +12873,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12675,19 +12894,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -12698,28 +12921,32 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
-      "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
-      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12728,28 +12955,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.hasown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
-      "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object.values": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
-      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12787,6 +13003,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -12836,17 +13053,18 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -12884,6 +13102,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/cli-spinners": {
@@ -12929,11 +13159,30 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -12949,6 +13198,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -12960,9 +13210,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13034,6 +13284,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -13145,23 +13396,16 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13169,7 +13413,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -13181,6 +13426,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13225,12 +13471,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -13405,7 +13651,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.15",
@@ -13442,14 +13689,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -13498,6 +13746,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13507,7 +13756,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.2.0",
@@ -13550,6 +13800,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -13580,7 +13831,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "7.3.0",
@@ -13604,12 +13856,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13636,15 +13886,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-fast-compare": {
@@ -13704,17 +13954,18 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-refractor": {
@@ -13732,6 +13983,21 @@
       },
       "peerDependencies": {
         "react": ">=18.0.0"
+      }
+    },
+    "node_modules/react-rx": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.2.2.tgz",
+      "integrity": "sha512-L0M51QxRnb5RndopV3lGPtG+O2rGVZl6aIzH1Fyx5ieOog/E947Xu00JERxksPJ9Lxn7kdME2wFtsWpiKTgI+A==",
+      "license": "MIT",
+      "dependencies": {
+        "observable-callback": "^1.0.3",
+        "react-compiler-runtime": "1.0.0",
+        "use-effect-event": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || >=19.0.0-0",
+        "rxjs": "^7"
       }
     },
     "node_modules/read-package-up": {
@@ -13856,17 +14122,20 @@
       }
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
-      "integrity": "sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "globalthis": "^1.0.3",
-        "which-builtin-type": "^1.1.3"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13910,14 +14179,18 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "set-function-name": "^2.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14014,13 +14287,16 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -14052,6 +14328,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -14082,36 +14359,22 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rolldown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.137.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -14121,21 +14384,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.3",
-        "@rolldown/binding-darwin-arm64": "1.1.3",
-        "@rolldown/binding-darwin-x64": "1.1.3",
-        "@rolldown/binding-freebsd-x64": "1.1.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
-        "@rolldown/binding-linux-arm64-musl": "1.1.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-musl": "1.1.3",
-        "@rolldown/binding-openharmony-arm64": "1.1.3",
-        "@rolldown/binding-wasm32-wasi": "1.1.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
-        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/run-applescript": {
@@ -14168,6 +14431,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -14203,14 +14467,16 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -14226,15 +14492,36 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
+    "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14247,9 +14534,9 @@
       "license": "MIT"
     },
     "node_modules/sanity": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-6.2.0.tgz",
-      "integrity": "sha512-BZ6qqGdOelGyL/3KybTKfOSdN5h95zvrM95+rHC+ibcBXXIeJd0zvH8LvSO/joqbffKN/COB6r0EIp9JRvBdgA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-6.3.0.tgz",
+      "integrity": "sha512-7ZTmLeofwpiwqOiXhqJIDUGFQYMAaH2BLFezQjKT0A0VlPQXEm/rlKLjJXoA+HvKYSRZ0wn3n1GvBItBojeikQ==",
       "license": "MIT",
       "dependencies": {
         "@algorithm.ts/lcs": "^4.0.6",
@@ -14260,25 +14547,27 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@isaacs/ttlcache": "^1.4.1",
         "@mux/mux-player-react": "^3.13.0",
-        "@portabletext/editor": "^7.7.0",
-        "@portabletext/html": "^1.0.3",
-        "@portabletext/patches": "^2.0.4",
-        "@portabletext/plugin-markdown-shortcuts": "^8.0.22",
-        "@portabletext/plugin-one-line": "^7.0.22",
-        "@portabletext/plugin-paste-link": "^4.0.22",
-        "@portabletext/plugin-typography": "^8.0.22",
+        "@portabletext/editor": "^7.9.0",
+        "@portabletext/html": "^1.1.0",
+        "@portabletext/patches": "^2.0.5",
+        "@portabletext/plugin-dnd": "^1.0.11",
+        "@portabletext/plugin-list-index": "^1.0.11",
+        "@portabletext/plugin-markdown-shortcuts": "^8.0.26",
+        "@portabletext/plugin-one-line": "^7.0.26",
+        "@portabletext/plugin-paste-link": "^4.0.26",
+        "@portabletext/plugin-typography": "^8.0.26",
         "@portabletext/react": "^6.2.0",
-        "@portabletext/sanity-bridge": "^3.1.5",
+        "@portabletext/sanity-bridge": "^3.2.0",
         "@portabletext/to-html": "^5.0.2",
         "@portabletext/toolkit": "^5.0.2",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.3.0",
         "@sanity/bifur-client": "^1.0.0",
-        "@sanity/cli": "^7.4.0",
+        "@sanity/cli": "^7.4.2",
         "@sanity/client": "^7.23.0",
         "@sanity/color": "^3.0.6",
         "@sanity/comlink": "^4.0.1",
-        "@sanity/diff": "6.2.0",
+        "@sanity/diff": "6.3.0",
         "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.2",
@@ -14291,20 +14580,20 @@
         "@sanity/message-protocol": "^0.23.0",
         "@sanity/migrate": "^7.0.3",
         "@sanity/mutate": "^0.18.1",
-        "@sanity/mutator": "6.2.0",
+        "@sanity/mutator": "6.3.0",
         "@sanity/presentation-comlink": "^2.1.0",
         "@sanity/preview-url-secret": "^4.0.7",
         "@sanity/prism-groq": "^1.1.2",
-        "@sanity/schema": "6.2.0",
-        "@sanity/sdk": "^2.14.1",
+        "@sanity/schema": "6.3.0",
+        "@sanity/sdk": "^2.15.0",
         "@sanity/telemetry": "^1.1.0",
-        "@sanity/types": "6.2.0",
+        "@sanity/types": "6.3.0",
         "@sanity/ui": "^3.2.0",
-        "@sanity/util": "6.2.0",
+        "@sanity/util": "6.3.0",
         "@sanity/uuid": "^3.0.3",
-        "@sentry/react": "^10.59.0",
+        "@sentry/react": "^10.62.0",
         "@tanstack/react-table": "^8.21.3",
-        "@tanstack/react-virtual": "^3.14.3",
+        "@tanstack/react-virtual": "^3.14.4",
         "@xstate/react": "^6.1.0",
         "classnames": "^2.5.1",
         "color2k": "^2.0.3",
@@ -14313,18 +14602,18 @@
         "debug": "^4.4.3",
         "exif-component": "^1.0.1",
         "fast-deep-equal": "3.1.3",
-        "groq-js": "^1.30.2",
+        "groq-js": "^1.30.3",
         "history": "^5.3.0",
-        "i18next": "^26.3.1",
+        "i18next": "^26.3.3",
         "is-hotkey-esm": "^1.0.0",
         "isomorphic-dompurify": "2.36.0",
         "json-reduce": "^3.0.0",
         "json-stable-stringify": "^1.3.0",
         "lodash-es": "^4.18.1",
         "mendoza": "^3.0.8",
-        "motion": "^12.40.0",
+        "motion": "^12.42.0",
         "nano-pubsub": "^3.0.0",
-        "nanoid": "^5.1.15",
+        "nanoid": "^5.1.16",
         "observable-callback": "^1.0.3",
         "path-to-regexp": "^6.3.0",
         "player.style": "^0.3.4",
@@ -14346,13 +14635,14 @@
         "semver": "^7.8.5",
         "shallow-equals": "^1.0.0",
         "speakingurl": "^14.0.1",
+        "swr": "^2.4.2",
         "urlpattern-polyfill": "10.1.0",
         "use-device-pixel-ratio": "^1.1.2",
         "use-hot-module-reload": "^2.0.0",
         "use-sync-external-store": "^1.6.0",
         "uuid": "^14.0.1",
         "web-vitals": "^5.3.0",
-        "xstate": "^5.32.1"
+        "xstate": "^5.32.2"
       },
       "bin": {
         "sanity": "bin/sanity"
@@ -14364,239 +14654,6 @@
         "react": "^19.2.2",
         "react-dom": "^19.2.2",
         "styled-components": "^6.1.15"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/editor": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-7.9.0.tgz",
-      "integrity": "sha512-zF6a1SghGA0u7TN3rWaWYHEuQhZgY1YWgmcswbyLnrtNqvn59HvCMJlDUt+h4W+Z5cKsIVImfJhLyzG4YgOfZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@portabletext/html": "^1.1.0",
-        "@portabletext/keyboard-shortcuts": "^2.1.3",
-        "@portabletext/markdown": "^1.4.2",
-        "@portabletext/patches": "^2.0.5",
-        "@portabletext/schema": "^2.2.2",
-        "@portabletext/to-html": "^5.0.2",
-        "@xstate/react": "^6.1.0",
-        "debug": "^4.4.3",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "xstate": "^5.32.2"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-markdown-shortcuts": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-8.0.26.tgz",
-      "integrity": "sha512-se+Xk5HZpupVWY938/ebGmcl5S2bd65w76EshGGrm2KH52snLggAiuSJEx0a1wGJdHEuRdOB8Uu7chADkfYK/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@portabletext/plugin-character-pair-decorator": "^8.0.26",
-        "@portabletext/plugin-input-rule": "^5.0.26"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-markdown-shortcuts/node_modules/@portabletext/plugin-character-pair-decorator": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-8.0.26.tgz",
-      "integrity": "sha512-UaFRqWIpc1qhlVWdUoXdg3Ec3mLuKr3xnHh4tLF/FCrc47g9uDgtHLXRssFaUwVPK1v55pzHlMuVq8ugA79F4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@xstate/react": "^6.1.0",
-        "xstate": "^5.32.2"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-markdown-shortcuts/node_modules/@portabletext/plugin-input-rule": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-5.0.26.tgz",
-      "integrity": "sha512-fnY0KkL6tTnTj9Ccsv4FJliFFlPrAyWUaSzuF5Gz6tNHDN8ixQbptfv3ZyNeu24OJEzbZwNW39fC9bz6sY4POw==",
-      "license": "MIT",
-      "dependencies": {
-        "@xstate/react": "^6.1.0",
-        "xstate": "^5.32.2"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-one-line": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-7.0.26.tgz",
-      "integrity": "sha512-C1KEeDjq0JIGD1sUxbZjjgOm1zhX+cm4i8pwlZ34uF4LTGxOdw6xVWChUXAxb8p1i2iHBeIepTP2ldfMxkR9Qw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-paste-link": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-paste-link/-/plugin-paste-link-4.0.26.tgz",
-      "integrity": "sha512-9Qgq9MUrmjkufk9smlXFGvRIS3bP9jkpEA/oZOZCuJYY6yVnBDxkPnRtuwcTd/B1u9FNHANDjlEdmLoKFzb5lA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-typography": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-8.0.26.tgz",
-      "integrity": "sha512-DqrI59PRBCNioIVUuxaoJkZUCPwkMfnmIWslx5U9ab3LwaTBH1KkWTT1mdKnmXnTTP6SMaa4OG55T/cTqGxxag==",
-      "license": "MIT",
-      "dependencies": {
-        "@portabletext/plugin-input-rule": "^5.0.26"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-typography/node_modules/@portabletext/plugin-input-rule": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-5.0.26.tgz",
-      "integrity": "sha512-fnY0KkL6tTnTj9Ccsv4FJliFFlPrAyWUaSzuF5Gz6tNHDN8ixQbptfv3ZyNeu24OJEzbZwNW39fC9bz6sY4POw==",
-      "license": "MIT",
-      "dependencies": {
-        "@xstate/react": "^6.1.0",
-        "xstate": "^5.32.2"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@sanity/icons": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.7.4.tgz",
-      "integrity": "sha512-O9MnckiDsphFwlRS8Q3kj3n+JYUZ0UzKRujnSikMZOKI0dayucRe4U2XvxikRhJnFhcEJXW2RkWJoBaCoup9Sw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
-      }
-    },
-    "node_modules/sanity/node_modules/@sanity/insert-menu": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-3.0.8.tgz",
-      "integrity": "sha512-O3g3ZpvRYLw4VBly4fKUzEK+2Mze8iBZfLpRjh8BgjLWSZ/9XCwrRUMJvKZ6z9qQI8zHRqwZQNslgEjETTTZ6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/icons": "^3.7.4",
-        "@sanity/ui": "^3.2.0",
-        "lodash-es": "^4.18.1",
-        "react-is": "^19.2.6"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@sanity/types": "*",
-        "react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@sanity/logos": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.2.2.tgz",
-      "integrity": "sha512-KIWFL7nYEOINXIzaTF9aVhd481hFF/ak+SRnpgksYuJXlo2hbY/UoEJBz6KhsEP5dfO/NwqG82QrkwzLvd6izA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/color": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
-      }
-    },
-    "node_modules/sanity/node_modules/@sanity/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-Q6VkqpESVMdYPxlaxckiJuZl0hhma4klTehuK6DMsB0KwhvJePHzxi7IJR3Uw7+4NyWx0Q7ohvVsey3VBdCW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/sanity/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
-    },
-    "node_modules/sanity/node_modules/react-rx": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.2.2.tgz",
-      "integrity": "sha512-L0M51QxRnb5RndopV3lGPtG+O2rGVZl6aIzH1Fyx5ieOog/E947Xu00JERxksPJ9Lxn7kdME2wFtsWpiKTgI+A==",
-      "license": "MIT",
-      "dependencies": {
-        "observable-callback": "^1.0.3",
-        "react-compiler-runtime": "1.0.0",
-        "use-effect-event": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": "^18.3 || >=19.0.0-0",
-        "rxjs": "^7"
-      }
-    },
-    "node_modules/sanity/node_modules/react-rx/node_modules/use-effect-event": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.3.tgz",
-      "integrity": "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/sanity/node_modules/semver": {
@@ -14637,12 +14694,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
@@ -14663,6 +14718,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -14685,14 +14741,31 @@
       }
     },
     "node_modules/set-function-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "define-data-property": "^1.0.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14726,6 +14799,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -14737,19 +14811,82 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14774,9 +14911,9 @@
       "license": "MIT"
     },
     "node_modules/skills": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/skills/-/skills-1.5.13.tgz",
-      "integrity": "sha512-eKYnMYCV4zlmXSikluxctEsn46i9ci18vb2d8b45yb4zTIvj3nFqMV3IrzF7VxqoXPF2AQnEZqVDu9tbPB2Atw==",
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/skills/-/skills-1.5.14.tgz",
+      "integrity": "sha512-oA0Wv2cfUnLaFHeDU+IwHfrbfyP42H1UTjjEZYnOtgujkMGL6uXKzmmIx8/6jPhqJiK1v7HbvRPBmhowg9N2lA==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
@@ -14793,6 +14930,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -14912,6 +15050,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
@@ -14958,35 +15110,75 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
-    "node_modules/string.prototype.matchall": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
-      "integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.5",
-        "regexp.prototype.flags": "^1.5.0",
-        "set-function-name": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14996,28 +15188,37 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15027,6 +15228,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -15060,6 +15262,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -15074,9 +15277,9 @@
       "license": "MIT"
     },
     "node_modules/styled-components": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
-      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.3.tgz",
+      "integrity": "sha512-wYXrhu+JmDjZ1Tv7O0OopGTfztbzun43Pjjhh2H+xc0h5A09dwpZ5FJbrifJDcL8g5TA9btpWOX2+iSRuJTExw==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
@@ -15109,21 +15312,6 @@
         }
       }
     },
-    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
@@ -15131,29 +15319,41 @@
       "license": "MIT"
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -15226,20 +15426,6 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar-stream/node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -15266,26 +15452,6 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
-    },
-    "node_modules/text-decoder/node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -15324,35 +15490,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tldts": {
@@ -15410,15 +15547,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-brand": {
@@ -15442,9 +15580,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -15490,6 +15629,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -15525,15 +15665,17 @@
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15543,16 +15685,19 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15562,14 +15707,21 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15584,30 +15736,41 @@
         "uuid": "^10.0.0"
       }
     },
-    "node_modules/typeid-js/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uc.micro": {
@@ -15617,15 +15780,19 @@
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15639,6 +15806,13 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -15771,6 +15945,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -15809,6 +15984,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/use-effect-event": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.3.tgz",
+      "integrity": "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/use-hot-module-reload": {
@@ -15904,15 +16088,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -16002,18 +16186,6 @@
         "url": "https://opencollective.com/antfu"
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -16083,6 +16255,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -16094,39 +16267,45 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-builtin-type": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
-      "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function.prototype.name": "^1.1.5",
-        "has-tostringtag": "^1.0.0",
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
-        "is-finalizationregistry": "^1.0.2",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
         "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16136,15 +16315,19 @@
       }
     },
     "node_modules/which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16184,6 +16367,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -16210,7 +16403,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -16292,9 +16486,9 @@
       "license": "MIT"
     },
     "node_modules/xstate": {
-      "version": "5.32.2",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.32.2.tgz",
-      "integrity": "sha512-uDrojEQYYb4cEeB/SpKDBQlnL2969N5ltmVak4jUMUC6VVRuhi7PCnTBxe4YlQ8YLzdaOEOuVR48CRQPE2o0Uw==",
+      "version": "5.32.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.32.3.tgz",
+      "integrity": "sha512-I8PDV+D9f5iuAGR/CjiQwf/7A+iiSWHsd16jWe/2Z1GQh4T4JQBYvpauqBK+SAU3TegOBtTvxcqAjhJnqeT0sg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -16313,7 +16507,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -16335,6 +16530,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16373,6 +16569,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/sanity-backend/package.json
+++ b/sanity-backend/package.json
@@ -9,28 +9,30 @@
     "start": "sanity start",
     "build": "sanity build",
     "deploy": "sanity deploy",
-    "deploy-graphql": "sanity graphql deploy"
+    "deploy-graphql": "sanity graphql deploy",
+    "lint": "eslint ."
   },
   "keywords": [
     "sanity"
   ],
   "dependencies": {
-    "@sanity/icons": "^2.6.0",
-    "@sanity/ui": "^3.2.0",
-    "@sanity/vision": "^6.2.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-icons": "^5.0.1",
-    "react-is": "^18.2.0",
-    "sanity": "^6.2.0",
-    "styled-components": "^6.0.7"
+    "@sanity/icons": "^3.7.7",
+    "@sanity/ui": "^3.3.0",
+    "@sanity/vision": "^6.3.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-icons": "^5.7.0",
+    "react-is": "^19.2.7",
+    "sanity": "^6.3.0",
+    "styled-components": "^6.4.3"
   },
   "devDependencies": {
-    "@sanity/eslint-config-studio": "^3.0.1",
-    "@types/react": "^18.0.25",
-    "eslint": "^8.6.0",
-    "prettier": "^3.0.2",
-    "typescript": "^5.1.6"
+    "@sanity/eslint-config-studio": "^6.0.0",
+    "@types/node": "^26.1.0",
+    "@types/react": "^19.2.17",
+    "eslint": "^9.39.4",
+    "prettier": "^3.9.4",
+    "typescript": "^5.9.3"
   },
   "overrides": {
     "@architect/utils": {
@@ -38,6 +40,16 @@
     },
     "@architect/hydrate": {
       "glob": "^10.5.0"
+    },
+    "@vercel/frameworks": {
+      "js-yaml": "3.15.0",
+      "smol-toml": "1.6.1"
+    },
+    "@sanity/uuid": {
+      "uuid": "11.1.1"
+    },
+    "typeid-js": {
+      "uuid": "11.1.1"
     }
   },
   "prettier": {

--- a/sanity-backend/plugins/sanity-plugin-tutorial/GetStartedTutorial.tsx
+++ b/sanity-backend/plugins/sanity-plugin-tutorial/GetStartedTutorial.tsx
@@ -12,19 +12,6 @@ import {
   useTheme,
 } from '@sanity/ui'
 import {CloseIcon} from '@sanity/icons'
-import styled, {css} from 'styled-components'
-
-const BlueColor = css`
-  color: ${({theme}) => theme.sanity.color.muted.primary.enabled.fg};
-`
-
-const LabelContainer = styled(Label)`
-  ${BlueColor}
-`
-
-const TextContainer = styled(Text)`
-  ${BlueColor}
-`
 
 export const GetStartedTutorial = () => {
   const [hideTutorial, setShowTutorial] = useState(
@@ -51,9 +38,7 @@ export const GetStartedTutorial = () => {
     <div ref={rootElement}>
       <Card tone="primary" padding={isSmallScreen ? 3 : 5} paddingBottom={isSmallScreen ? 4 : 6}>
         <Flex justify={isSmallScreen ? 'space-between' : 'flex-end'} align="center">
-          {isSmallScreen && (
-            <LabelContainer forwardedAs="p">Your Sanity Studio is all set up!</LabelContainer>
-          )}
+          {isSmallScreen && <Label as="p">Your Sanity Studio is all set up!</Label>}
 
           <Button
             aria-label="Close dialog"
@@ -66,9 +51,9 @@ export const GetStartedTutorial = () => {
         <Stack space={5}>
           {!isSmallScreen && (
             <>
-              <LabelContainer forwardedAs="p" align="center">
+              <Label as="p" align="center">
                 Get started with sanity
-              </LabelContainer>
+              </Label>
 
               <Heading as="h1" size={4} align="center">
                 Your Sanity Studio is all set up!
@@ -77,14 +62,14 @@ export const GetStartedTutorial = () => {
           )}
 
           <Container width={1}>
-            <TextContainer
-              forwardedAs="p"
+            <Text
+              as="p"
               size={isSmallScreen ? 1 : undefined}
               align={isSmallScreen ? 'left' : 'center'}
             >
               Next, our docs will guide you through building schemas, adding content, and connecting
               a frontend. You’ll see updates reflected in your Studio below.
-            </TextContainer>
+            </Text>
           </Container>
 
           <Flex justify={isSmallScreen ? 'flex-start' : 'center'}>

--- a/sanity-backend/sanity.config.ts
+++ b/sanity-backend/sanity.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig, isDev} from 'sanity'
 import {visionTool} from '@sanity/vision'
-import {deskTool} from 'sanity/desk'
+import {structureTool} from 'sanity/structure'
 import {schemaTypes} from './schemas'
 import {getStartedPlugin} from './plugins/sanity-plugin-tutorial'
 
@@ -13,7 +13,7 @@ export default defineConfig({
   projectId: 'h48br789',
   dataset: 'production',
 
-  plugins: [deskTool(), visionTool(), ...(isDev ? devOnlyPlugins : [])],
+  plugins: [structureTool(), visionTool(), ...(isDev ? devOnlyPlugins : [])],
 
   schema: {
     types: schemaTypes,

--- a/sanity-backend/tsconfig.json
+++ b/sanity-backend/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Production release

Brings `main` up to the fully-tested `Development` state. **Clears all 13 open Dependabot alerts** (all in `sanity-backend/package-lock.json`) — they persisted only because Dependabot scans the default branch (`main`), and the fixes were on `Development`.

Built as a clean branch off `main` (tree set to exactly match `Development`) to avoid the squash-merge history divergence that made a direct `Development` -> `main` PR conflict. Resulting tree is identical to `Development`.

### What lands on main
- **CSS Modules refactor** (#81) — inline-style sprawl -> CSS Modules + design tokens
- **React 19 + react-router 7** migration
- **Vite 8 + plugin-react 6 + Vitest 4** upgrade
- **Sanity Studio upgrade** (#92) — cleared all sanity-backend vulnerabilities, 0 vulns
- **react-frontend dependency batch** (#93) — react-markdown 10, @vercel/analytics 2, uuid 14, web-vitals 5, typescript 6
- Removes obsolete `react-app-env.d.ts` and `sanity-backend/.eslintrc` (replaced by `vite-env.d.ts` / `eslint.config.mjs`)

### Verification
Every included change was tested green (build + tsc + lint) and passed Vercel preview checks on Development before landing here.