### PR TITLE
chore(dependabot): reduce PR/email noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,44 +2,61 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  # Frontend (React + Vite) dependencies
+  # Frontend (React + Vite) dependencies — the deployed app.
+  # All update types are grouped into a single PR to minimize noise.
   - package-ecosystem: "npm"
     directory: "/react-frontend"
     target-branch: "Development"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "react-frontend"
     groups:
-      react-frontend-minor-patch:
+      react-frontend:
+        patterns:
+          - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
-  # Sanity backend dependencies
+  # Sanity backend dependencies — CMS admin tool, NOT deployed.
+  # Lower priority, so checked monthly and fully grouped.
   - package-ecosystem: "npm"
     directory: "/sanity-backend"
     target-branch: "Development"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "sanity-backend"
     groups:
-      sanity-backend-minor-patch:
+      sanity-backend:
+        patterns:
+          - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
-  # GitHub Actions workflows
+  # GitHub Actions workflows — grouped into a single PR.
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "Development"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Reduces future Dependabot email volume.

- **Group all update types** (major/minor/patch) into a single PR per ecosystem — previously only minor/patch were grouped, so every major opened its own PR (the source of the recent #83-#88 flood).
- **Lower open-PR limit** 10 -> 5 per ecosystem.
- **sanity-backend -> monthly** schedule (it's the non-deployed CMS admin tool; lower priority).

Targets `main` directly because Dependabot reads `.github/dependabot.yml` from the repository's default branch.