### PR TITLE
chore(vercel): skip deploys when frontend is unchanged

### DIFF
--- a/react-frontend/vercel.json
+++ b/react-frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
+}


### PR DESCRIPTION
Conserves Hobby-tier deployment quota (100 deploys/day, per account).

Adds `react-frontend/vercel.json` with an `ignoreCommand` that cancels the Vercel build when a push doesn't change anything under the frontend (the project's Root Directory is `react-frontend`):

`git diff HEAD^ HEAD --quiet .` — exit 0 skips the build, non-zero builds.

**Effect:** changes to `sanity-backend`, docs, `.github` config, README, and CI no longer trigger a full deploy. Previews for real frontend changes are unaffected. This session alone would have skipped ~4 unnecessary deployments.

Targets `main` so production stops deploying on non-frontend commits; a companion PR syncs it to `Development`.