### PR TITLE
chore(vercel): sync skip-builds config to Development

### DIFF
--- a/react-frontend/vercel.json
+++ b/react-frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
+}


### PR DESCRIPTION
Backports the `react-frontend/vercel.json` ignoreCommand merged to main in #100, so Development and feature branches cut off it also skip deploys when the frontend is unchanged.