### PR TITLE
Release: frontend code-quality follow-ups to production

### DIFF
--- a/react-frontend/eslint.config.mjs
+++ b/react-frontend/eslint.config.mjs
@@ -30,8 +30,22 @@ export default tseslint.config(
             ],
             '@typescript-eslint/no-unused-vars': [
                 'warn',
-                { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+                {
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                    ignoreRestSiblings: true,
+                },
             ],
+        },
+    },
+    {
+        // Route containers export `default ContainerWrap(X)`. The react-spring
+        // HOC is not detectable by eslint-plugin-react-refresh, so the rule
+        // false-positives here. Fast Refresh isn't relevant for these entry
+        // components, so disable the rule for them only.
+        files: ['src/containers/**/index.tsx'],
+        rules: {
+            'react-refresh/only-export-components': 'off',
         },
     },
     prettier

--- a/react-frontend/src/components/Button/index.test.tsx
+++ b/react-frontend/src/components/Button/index.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Button from './index';
+
+describe('Button', () => {
+    it('renders the provided text', () => {
+        render(<Button text="Click me" />);
+        expect(
+            screen.getByRole('button', { name: 'Click me' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders children', () => {
+        render(<Button>Child content</Button>);
+        expect(
+            screen.getByRole('button', { name: 'Child content' })
+        ).toBeInTheDocument();
+    });
+
+    it('calls onClick when clicked', async () => {
+        const onClick = vi.fn();
+        render(<Button text="Press" onClick={onClick} />);
+        await userEvent.click(screen.getByRole('button', { name: 'Press' }));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a native button element with type="button"', () => {
+        render(<Button text="Native" />);
+        expect(screen.getByRole('button', { name: 'Native' })).toHaveAttribute(
+            'type',
+            'button'
+        );
+    });
+});

--- a/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/AncherLinkMarkdown.tsx
@@ -10,9 +10,9 @@ type AncherLinkMarkdownProps = {
     node?: Element,
 } & React.HTMLAttributes<HTMLAnchorElement>;
 
-const iconType = ['doc', 'link'] as const;
+type IconType = 'doc' | 'link';
 
-const iconName: Record<typeof iconType[number], IconDefinition> = {
+const iconName: Record<IconType, IconDefinition> = {
     doc: faFileAlt,
     link: faLink,
 }
@@ -24,7 +24,7 @@ const AncherLinkMarkdown = ({ node, ...props }: AncherLinkMarkdownProps) => {
     const matchButtonLink = /\[([^|]+)(?:\|(doc|link))?\]/.exec(title);
     if (matchButtonLink) {
         const title = matchButtonLink[1];
-        const icon = iconName[(matchButtonLink[2] as typeof iconType[number]) || 'link'];
+        const icon = iconName[(matchButtonLink[2] as IconType) || 'link'];
 
         return (
             <Button

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -3,7 +3,7 @@ import type { Element, RootContent } from 'hast'
 import MainSection from '../MainSection';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { markdownComponents } from '.';
+import { markdownComponents } from './markdownComponents';
 import { v4 as uuid } from 'uuid';
 import { cx } from '../../utils/cx';
 import styles from './BlockquoteMarkdown.module.css';

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { Element, RootContent } from 'hast'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { markdownComponents } from '.';
+import { markdownComponents } from './markdownComponents';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import Button from '../Button';
 import { v4 as uuid } from 'uuid';

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureButton.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureButton.ts
@@ -1,9 +1,9 @@
 import type { Node } from 'hast'
 import type { customType } from '.'
 
-export const captureButton = (node: Node): customType => ({
+export const captureButton = (_node: Node): customType => ({
     regex: /\[\[([a-zA-Z0-9\s]+)\]\]/,
-    callback: (fullText: string, content: string) => {
+    callback: (_fullText: string, content: string) => {
         return {
             type: 'strong',
             children: [

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
@@ -2,12 +2,13 @@ import type { Node } from 'hast'
 import type { PhrasingContent } from 'mdast'
 import type { customType } from '.'
 
-export const captureGap = (node: Node): customType => ({
+export const captureGap = (_node: Node): customType => ({
     regex: /\[gap\]/,
-    callback: (fullText: string) => ({
+    callback: (_fullText: string) => ({
         type: 'paragraph',
         children: [],
         data: {
+            hName: 'span',
             hProperties: {
                 style: "margin: 0 1rem 1rem 0; display: inline-block;"
             }

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
@@ -2,13 +2,14 @@ import type { Node } from 'hast'
 import type { PhrasingContent } from 'mdast'
 import type { customType } from '.'
 
-export const captureNewline = (node: Node): customType => ({
+export const captureNewline = (_node: Node): customType => ({
     regex: /\[newline\]/,
-    callback: (fullText: string) => {
+    callback: (_fullText: string) => {
         return ({
             type: 'paragraph',
             children: [],
             data: {
+                hName: 'span',
                 hProperties: {
                     style: "margin: 0.5rem 0; display: grid;"
                 }

--- a/react-frontend/src/components/HTMLMarkdown/index.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/index.tsx
@@ -1,34 +1,12 @@
-import ReactMarkdown, { Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks'
-import HrMarkdown from './HrMarkdown';
-import UlMarkdown from './UlMarkdown';
-import LiMarkdown from './LiMarkdown';
-import HeadingMarkdown from './HeadingMarkdown';
-import SpanMarkdown from './SpanMarkdown';
-import BlockquoteMarkdown from './BlockquoteMarkdown';
-import AncherLinkMarkdown from './AncherLinkMarkdown';
+import { markdownComponents } from './markdownComponents';
 import { customBlockquote, customHighlightText, customImage, customText } from './customPlugins';
 
 type Props = {
     readonly markdown: string
 }
-
-export const markdownComponents: Components = {
-    hr: ({ node, ...props }) => <HrMarkdown {...props} />,
-    ul: ({ node, ...props }) => <UlMarkdown {...props} />,
-    li: ({ node, ...props }) => <LiMarkdown {...props} />,
-    h1: ({ node, ...props }) => <HeadingMarkdown headingNumber='one' {...props} />,
-    h2: ({ node, ...props }) => <HeadingMarkdown headingNumber='two' {...props} />,
-    h3: ({ node, ...props }) => <HeadingMarkdown headingNumber='three' {...props} />,
-    h4: ({ node, ...props }) => <HeadingMarkdown headingNumber='four' {...props} />,
-    h5: ({ node, ...props }) => <HeadingMarkdown headingNumber='five' {...props} />,
-    h6: ({ node, ...props }) => <HeadingMarkdown headingNumber='six' {...props} />,
-    span: ({ node, ...props }) => <SpanMarkdown node={node} {...props} />,
-    strong: ({ node, ...props }) => <SpanMarkdown node={node} {...props} />,
-    blockquote: ({ node, ...props }) => <BlockquoteMarkdown node={node} {...props} />,
-    a: ({ node, ...props }) => <AncherLinkMarkdown node={node} {...props} />,
-};
 
 function HTMLMarkdown({ markdown }: Props) {
     return (

--- a/react-frontend/src/components/HTMLMarkdown/markdownComponents.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/markdownComponents.tsx
@@ -1,0 +1,24 @@
+import { Components } from 'react-markdown';
+import HrMarkdown from './HrMarkdown';
+import UlMarkdown from './UlMarkdown';
+import LiMarkdown from './LiMarkdown';
+import HeadingMarkdown from './HeadingMarkdown';
+import SpanMarkdown from './SpanMarkdown';
+import BlockquoteMarkdown from './BlockquoteMarkdown';
+import AncherLinkMarkdown from './AncherLinkMarkdown';
+
+export const markdownComponents: Components = {
+    hr: ({ node, ...props }) => <HrMarkdown {...props} />,
+    ul: ({ node, ...props }) => <UlMarkdown {...props} />,
+    li: ({ node, ...props }) => <LiMarkdown {...props} />,
+    h1: ({ node, ...props }) => <HeadingMarkdown headingNumber='one' {...props} />,
+    h2: ({ node, ...props }) => <HeadingMarkdown headingNumber='two' {...props} />,
+    h3: ({ node, ...props }) => <HeadingMarkdown headingNumber='three' {...props} />,
+    h4: ({ node, ...props }) => <HeadingMarkdown headingNumber='four' {...props} />,
+    h5: ({ node, ...props }) => <HeadingMarkdown headingNumber='five' {...props} />,
+    h6: ({ node, ...props }) => <HeadingMarkdown headingNumber='six' {...props} />,
+    span: ({ node, ...props }) => <SpanMarkdown node={node} {...props} />,
+    strong: ({ node, ...props }) => <SpanMarkdown node={node} {...props} />,
+    blockquote: ({ node, ...props }) => <BlockquoteMarkdown node={node} {...props} />,
+    a: ({ node, ...props }) => <AncherLinkMarkdown node={node} {...props} />,
+};

--- a/react-frontend/src/components/ProjectCard/Content.tsx
+++ b/react-frontend/src/components/ProjectCard/Content.tsx
@@ -13,7 +13,7 @@ type ContentProps = {
     readonly demoLink?: string,
 }
 
-function Content({ title, description, technologies, projectLink, demoLink }: ContentProps) {
+function Content({ description, technologies, projectLink, demoLink }: ContentProps) {
     return (
         <div className={styles.content}>
             <HTMLMarkdown markdown={description} />

--- a/react-frontend/src/components/ProjectCard/index.tsx
+++ b/react-frontend/src/components/ProjectCard/index.tsx
@@ -18,7 +18,6 @@ function ProjectCard({
     imgSrc = "images/placeholder.png",
     projectLink,
     demoLink,
-    title,
     description,
     technologies
 }: ProjectCardProps) {

--- a/react-frontend/src/containers/Education/Content/CoursesItems.tsx
+++ b/react-frontend/src/containers/Education/Content/CoursesItems.tsx
@@ -8,7 +8,7 @@ import surfaces from '../../../styles/surfaces.module.css';
 function CoursesItems({ courses }: Readonly<Pick<SanityEducationPage["education"], "courses">>) {
     return (
         <>
-            {courses.map((course, index) => {
+            {courses.map((course) => {
                 return (
                     <MainSection
                         key={course.description}>

--- a/react-frontend/src/contexts/ThemeContext.tsx
+++ b/react-frontend/src/contexts/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useMemo, useState } from 'react';
 import backgroundImage from '../assets/background.svg';
 import { ColorLevels, Theme } from '../Types';
 
@@ -95,13 +95,3 @@ export default function ThemeContext({ children }: ThemeContextProps) {
         </Context.Provider>
     )
 }
-
-function useThemeContext() {
-    const result = useContext(Context);
-    if (result == null) {
-        throw Error("Error happened while creating the ThemeContext!")
-    }
-    return { ...result }
-}
-
-export { useThemeContext };

--- a/react-frontend/src/utils/cx.test.ts
+++ b/react-frontend/src/utils/cx.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { cx } from './cx';
+
+describe('cx', () => {
+    it('joins truthy class strings with a single space', () => {
+        expect(cx('a', 'b', 'c')).toBe('a b c');
+    });
+
+    it('drops falsy values (false, null, undefined, empty string)', () => {
+        expect(cx('a', false, null, undefined, '', 'b')).toBe('a b');
+    });
+
+    it('supports conditional expressions', () => {
+        const active = true;
+        const disabled = false;
+        expect(cx('base', active && 'active', disabled && 'disabled')).toBe(
+            'base active'
+        );
+    });
+
+    it('returns an empty string when nothing is truthy', () => {
+        expect(cx(false, null, undefined, '')).toBe('');
+    });
+});

--- a/react-frontend/vercel.json
+++ b/react-frontend/vercel.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "outputDirectory": "build",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
 }


### PR DESCRIPTION
Promotes the code-quality follow-ups (merged to Development in #102) to production.

- Lint: 0 warnings (fast-refresh, unused-vars, dead code cleanup)
- Fix invalid <p>-in-<p> DOM nesting in markdown spacers
- Add Vitest tests (cx, Button) - 8 tests
- vercel.json: framework=vite + outputDirectory=build + SPA rewrite

Verified on the Development preview: build OK, lint/tsc clean, tests pass, deploy Ready.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>