### PR TITLE
refactor(frontend): eliminate remaining inline styles (Header, LinkButton)

### DIFF
--- a/react-frontend/src/components/MainSection/Header.module.css
+++ b/react-frontend/src/components/MainSection/Header.module.css
@@ -2,6 +2,15 @@
     display: inline;
 }
 
+.titleText {
+    display: inline;
+    margin-right: 0.5rem;
+}
+
+.iconText {
+    display: inline-block;
+}
+
 .headerText {
     display: inline;
 }

--- a/react-frontend/src/components/MainSection/Header.tsx
+++ b/react-frontend/src/components/MainSection/Header.tsx
@@ -5,9 +5,6 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { cx } from '../../utils/cx';
 import styles from './Header.module.css';
 
-const titleTextStyle = { display: 'inline', marginRight: '0.5rem' } as const;
-const iconTextStyle = { display: 'inline-block' } as const;
-
 type HeaderProps = {
     readonly title: string,
     readonly link?: string,
@@ -27,14 +24,14 @@ export default function Header({ title, link, subtitle }: HeaderProps) {
                 <Text
                     variant={"h3"}
                     onClick={link ? headerOnCLickHandler : undefined}
-                    style={titleTextStyle}>
+                    className={styles.titleText}>
                     <span className={cx(styles.headerText, link && styles.pointer)}>{title}</span>
                 </Text>
                 {link && (
                     <Text
                         variant={"h3"}
                         onClick={headerOnCLickHandler}
-                        style={iconTextStyle}>
+                        className={styles.iconText}>
                         <span className={cx(styles.linkText, styles.pointer)}>
                             <ExternalLinkIcon />
                         </span>

--- a/react-frontend/src/components/Navbar/Links/LinkButton.module.css
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.module.css
@@ -1,3 +1,15 @@
-.link {
+/* Self-compound (.link.link) raises specificity to 0-2-0 so these token-based
+   colours win over Button's single-class .button/.ghost rules regardless of
+   CSS bundle order — without resorting to inline styles or !important. */
+.link.link {
     font-weight: 500;
+    background-color: transparent;
+    color: var(--color-base-400);
+    opacity: 0.9;
+}
+
+.link.active {
+    background-color: var(--color-base-200);
+    color: var(--color-base-800);
+    opacity: 1;
 }

--- a/react-frontend/src/components/Navbar/Links/LinkButton.tsx
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.tsx
@@ -1,7 +1,8 @@
 import Button from '../../Button'
 import { PortfolioPathes } from '../../../Types';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
+import { cx } from '../../../utils/cx';
 import styles from './LinkButton.module.css';
 
 type LinkButtonProps = {
@@ -12,23 +13,12 @@ type LinkButtonProps = {
 
 function LinkButton({ path, pageName, onClick }: LinkButtonProps) {
     const navigate = useNavigate();
-    const active = useMatch(`/${path}`);
-    // Active/inactive colours depend on the current route, so they stay as
-    // token-based inline styles; the ghost variant strips the default border/shadow.
-    const linkButtonStyle = useMemo(() => {
-        const linkActive = active !== null;
-        return {
-            backgroundColor: linkActive ? 'var(--color-base-200)' : 'transparent',
-            color: linkActive ? 'var(--color-base-800)' : 'var(--color-base-400)',
-            opacity: linkActive ? 1 : 0.9,
-        };
-    }, [active]);
+    const active = useMatch(`/${path}`) !== null;
 
     return (
         <Button
             variant="ghost"
-            className={styles.link}
-            style={linkButtonStyle}
+            className={cx(styles.link, active && styles.active)}
             pointer={true}
             size='md'
             onClick={() => {

--- a/react-frontend/src/components/Text/index.tsx
+++ b/react-frontend/src/components/Text/index.tsx
@@ -10,12 +10,13 @@ const variantTags = {
 
 type TextProps = {
     readonly variant?: keyof typeof variantTags;
+    readonly className?: string;
     readonly style?: CSSProperties;
     readonly onClick?: () => void;
     readonly children: ReactNode;
 };
 
-export default function Text({ variant = 'body', style, onClick, children }: TextProps) {
+export default function Text({ variant = 'body', className, style, onClick, children }: TextProps) {
     const Tag = variantTags[variant];
 
     // Only expose keyboard/focus affordances when the node is actually interactive.
@@ -34,7 +35,7 @@ export default function Text({ variant = 'body', style, onClick, children }: Tex
         : {};
 
     return (
-        <Tag style={style} {...interactiveProps}>
+        <Tag className={className} style={style} {...interactiveProps}>
             {children}
         </Tag>
     );


### PR DESCRIPTION
Completes the "no inline CSS" goal of the CSS Modules refactor. Base: `Development`.

## Changes
- **`Text`**: added a `className` prop so callers can pass module classes instead of `style`.
- **`MainSection/Header`**: the two **static** inline style objects (`{ display:'inline', marginRight:'0.5rem' }`, `{ display:'inline-block' }`) moved to `Header.module.css` as `.titleText` / `.iconText`. This was the one genuine static leftover.
- **`Navbar/Links/LinkButton`**: replaced the route-state inline `style` object with an `.active` class toggle. A self-compound `.link.link` selector (specificity 0-2-0) deterministically wins over Button's single-class `.button`/`.ghost` rules regardless of CSS bundle order — no `!important`, no inline styles. Also drops the now-unnecessary `useMemo`.

## Remaining inline styles are intentional (not violations)
react-spring `animated.div`, `style` passthrough props on primitives, and runtime/AST-driven values (bg URL, `color-mix`, hover scale, markdown text-align/image dims).

## Verification
`eslint` 0 warnings · `tsc` clean · `vitest run` 8/8 · `vite build` OK

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>