### PR TITLE
fix(markdown): P1 correctness bugs (invalid nesting, unstable keys) + DSL tests

### DIFF
--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -32,7 +32,6 @@
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "unist-util-visit": "^5.1.0",
-        "uuid": "^14.0.1",
         "web-vitals": "^5.3.0"
       },
       "devDependencies": {
@@ -6277,19 +6276,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -27,7 +27,6 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "unist-util-visit": "^5.1.0",
-    "uuid": "^14.0.1",
     "web-vitals": "^5.3.0"
   },
   "scripts": {

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -4,7 +4,6 @@ import MainSection from '../MainSection';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { markdownComponents } from './markdownComponents';
-import { v4 as uuid } from 'uuid';
 import { cx } from '../../utils/cx';
 import styles from './BlockquoteMarkdown.module.css';
 
@@ -23,8 +22,8 @@ const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownPro
                 br: () => null,
             },
         }));
-        return content?.map((element) => (
-            <Fragment key={uuid()}>{element}</Fragment>
+        return content?.map((element, index) => (
+            <Fragment key={index}>{element}</Fragment>
         ));
     }, [node?.children]);
 

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
@@ -78,4 +78,12 @@ describe('HTMLMarkdown — custom DSL', () => {
         expect(btn?.textContent).toContain('Google');
         expect(btn?.querySelector('svg')).not.toBeNull();
     });
+
+    it('a standalone [text](url) link does not produce invalid <div> inside <p>', () => {
+        const c = renderMd('[Google](https://google.com)');
+        // AncherLinkMarkdown renders a block Header; it must not sit inside a <p>.
+        expect(c.textContent).toContain('Google');
+        const nestedDivInP = c.querySelector('p div');
+        expect(nestedDivInP).toBeNull();
+    });
 });

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import HTMLMarkdown from './index';
+
+const renderMd = (markdown: string) =>
+    render(<HTMLMarkdown markdown={markdown} />).container;
+
+describe('HTMLMarkdown — custom DSL', () => {
+    it('[[text]] renders a button with the label', () => {
+        const c = renderMd('[[Click Me]]');
+        const btn = c.querySelector('button');
+        expect(btn).not.toBeNull();
+        expect(btn?.textContent).toBe('Click Me');
+    });
+
+    it('[gap] renders an inline <span> spacer, never a nested <p>', () => {
+        const c = renderMd('left[gap]right');
+        expect(c.querySelector('span')).not.toBeNull();
+        expect(c.querySelector('p p')).toBeNull();
+    });
+
+    it('[newline] renders an inline <span> spacer, never a nested <p>', () => {
+        const c = renderMd('top[newline]bottom');
+        expect(c.querySelector('span')).not.toBeNull();
+        expect(c.querySelector('p p')).toBeNull();
+    });
+
+    it('[center] applies text-align to the block', () => {
+        const c = renderMd('[center]hello');
+        expect(c.querySelector('[style*="text-align: center"]')).not.toBeNull();
+    });
+
+    it('# heading renders an <h1> with the heading style', () => {
+        const c = renderMd('# My Title');
+        const h1 = c.querySelector('h1');
+        expect(h1?.textContent).toBe('My Title');
+        expect(h1?.className).toMatch(/h1/);
+    });
+
+    it('- list renders custom <li> items', () => {
+        const c = renderMd('- first\n- second');
+        const items = c.querySelectorAll('li');
+        expect(items).toHaveLength(2);
+        expect(items[0].textContent).toBe('first');
+    });
+
+    it('**!text!** renders a secondary highlighted text span', () => {
+        const c = renderMd('**!hot!**');
+        const span = c.querySelector('[class*="highlightTextSecondary"]');
+        expect(span).not.toBeNull();
+        expect(span?.textContent).toBe('hot');
+    });
+
+    it('**-area-** renders a base highlight-area span', () => {
+        const c = renderMd('**-area-**');
+        const span = c.querySelector('[class*="highlightAreaBase"]');
+        expect(span).not.toBeNull();
+        expect(span?.textContent).toBe('area');
+    });
+
+    it('**!-area-!** renders a secondary highlight-area span', () => {
+        const c = renderMd('**!-wow-!**');
+        const span = c.querySelector('[class*="highlightAreaSecondary"]');
+        expect(span).not.toBeNull();
+        expect(span?.textContent).toBe('wow');
+    });
+
+    it('> [!variation] title blockquote renders title and body', () => {
+        const c = renderMd('> [!note] Heads up\n> body text');
+        expect(c.querySelector('[class*="blockquote"]')).not.toBeNull();
+        expect(c.textContent).toContain('Heads up');
+        expect(c.textContent).toContain('body text');
+    });
+
+    it('[[label|link]](url) renders a button with an icon', () => {
+        const c = renderMd('[[Google|link]](https://google.com)');
+        const btn = c.querySelector('button');
+        expect(btn?.textContent).toContain('Google');
+        expect(btn?.querySelector('svg')).not.toBeNull();
+    });
+});

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.image.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.image.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import HTMLMarkdown from './index';
+
+describe('HTMLMarkdown — image rendering', () => {
+    it('does not nest block elements inside <p> (valid DOM)', () => {
+        const { container } = render(
+            <HTMLMarkdown markdown={'![cat](/cat.png =100x80|center)'} />
+        );
+        // The image and its wrappers must not live inside a <p>.
+        const img = container.querySelector('img');
+        expect(img).not.toBeNull();
+        expect(img?.closest('p')).toBeNull();
+    });
+
+    it('renders the image with its alt text and src', () => {
+        const { container } = render(
+            <HTMLMarkdown markdown={'![a cat](/cat.png =100x80|center)'} />
+        );
+        const img = container.querySelector('img');
+        expect(img?.getAttribute('alt')).toBe('a cat');
+        expect(img?.getAttribute('src')).toBe('/cat.png');
+    });
+});

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -4,7 +4,6 @@ import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { markdownComponents } from './markdownComponents';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import Button from '../Button';
-import { v4 as uuid } from 'uuid';
 import styles from './SpanMarkdown.module.css';
 
 
@@ -37,8 +36,8 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
                 br: () => null,
             },
         }));
-        return result?.map((element) => (
-            <Fragment key={uuid()}>{element}</Fragment>
+        return result?.map((element, index) => (
+            <Fragment key={index}>{element}</Fragment>
         ));
     }, [node?.children]);
     const spanElement = useMemo((): SpanElementType => {

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
@@ -89,6 +89,7 @@ export const customImage = () => {
                         type: 'paragraph',
                         children: [imageNode],
                         data: {
+                            hName: 'div',
                             hProperties: {
                                 className: 'image-container',
                                 style: Object.entries(imageWrapperNodeStyle(parseInt(width), parseInt(height)))
@@ -100,6 +101,7 @@ export const customImage = () => {
                 }
                 currentNode.children = imageNodes;
                 currentNode.data = {
+                    hName: 'div',
                     hProperties: {
                         className: 'image',
                         style: Object.entries(imageContainerStyle(align))

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customLink.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customLink.ts
@@ -1,0 +1,22 @@
+import { visit } from 'unist-util-visit';
+import { Nodes, Parent } from 'mdast'
+
+/**
+ * A standalone link (`[text](url)`) is rendered by AncherLinkMarkdown as a
+ * block-level Header/Button. react-markdown wraps it in a <p>, producing an
+ * invalid <p><div>…</div></p>. When a paragraph contains only a link, render
+ * the paragraph as a <div> so the block content nests validly.
+ */
+export const customLink = () => {
+    return function (tree: Nodes) {
+        visit(tree, 'paragraph', (node: Nodes) => {
+            const paragraph = node as Parent;
+            if (paragraph.children.length === 1 && paragraph.children[0].type === 'link') {
+                paragraph.data = {
+                    ...(paragraph.data ?? {}),
+                    hName: 'div',
+                };
+            }
+        });
+    };
+};

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/index.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/index.ts
@@ -2,3 +2,4 @@ export { customText } from './customText';
 export { customBlockquote } from './customBlockquote';
 export { customHighlightText } from './customHighlightText';
 export { customImage } from './customImage';
+export { customLink } from './customLink';

--- a/react-frontend/src/components/HTMLMarkdown/index.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/index.tsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks'
 import { markdownComponents } from './markdownComponents';
-import { customBlockquote, customHighlightText, customImage, customText } from './customPlugins';
+import { customBlockquote, customHighlightText, customImage, customLink, customText } from './customPlugins';
 
 type Props = {
     readonly markdown: string
@@ -15,6 +15,7 @@ function HTMLMarkdown({ markdown }: Props) {
                 remarkGfm,
                 remarkBreaks,
                 customImage,
+                customLink,
                 customText,
                 customHighlightText,
                 customBlockquote


### PR DESCRIPTION
First batch of the markdown deep-review — the **P1 correctness bugs + a test safety net**. Base: `Development`.

## Fixes
1. **Invalid `<p>` nesting in images** (`customImage`) — container/wrapper nodes stayed `type: 'paragraph'`, producing `<p><p><img>`. Now `hName: 'div'`.
2. **Invalid `<div>`-in-`<p>` for standalone links** — `[text](url)` renders a block Header but react-markdown wraps it in `<p>`. New `customLink` plugin renders link-only paragraphs as `<div>`.
3. **`uuid()` React keys → stable keys** — `key={uuid()}` regenerated every render, remounting all markdown children (perf/state loss). Now index-based keys. Removed the now-unused `uuid` dependency.

## Tests (new safety net — was zero coverage)
- `HTMLMarkdown.dsl.test.tsx` — 12 tests: `[[button]]`, `[gap]`/`[newline]` spacers (assert no nested `<p>`), `[center]`, headings, lists, `!text!`/`-area-`/`!-area-!` highlights, blockquote callouts, icon button-links, and the link-nesting regression.
- `HTMLMarkdown.image.test.tsx` — 2 tests: image nesting + alt/src.
- Both bug fixes are proven by tests that fail without the fix.

## Verification
`eslint` 0 warnings · `tsc` clean · `vitest run` **22/22** · `vite build` OK

Deferred to follow-up PRs (P2/P3): dedupe the recursive `toJsxRuntime` rendering, replace `customBlockquote`'s magic stack indices, move `customImage` inline styles to classes/vars, fluid type scale, `<hr>` semantics.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>