### PR TITLE
refactor(markdown): structural + design cleanup (dedup, semantics, tokens, no-inline-CSS)

### DIFF
--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -1,9 +1,7 @@
 import { useMemo } from 'react';
-import type { Element, RootContent } from 'hast'
+import type { Element } from 'hast'
 import MainSection from '../MainSection';
-import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
-import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { markdownComponents } from './markdownComponents';
+import { useRenderedMarkdownChildren } from './renderMarkdownChildren';
 import { cx } from '../../utils/cx';
 import styles from './BlockquoteMarkdown.module.css';
 
@@ -15,17 +13,7 @@ type BlockquoteMarkdownProps = {
 
 
 const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownProps) => {
-    const contentJSXElementsFromAST = useMemo(() => {
-        const content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
-            Fragment, jsx, jsxs, passNode: true, components: {
-                ...markdownComponents,
-                br: () => null,
-            },
-        }));
-        return content?.map((element, index) => (
-            <Fragment key={index}>{element}</Fragment>
-        ));
-    }, [node?.children]);
+    const contentJSXElementsFromAST = useRenderedMarkdownChildren(node);
 
     // By default it will be without-background and base color
     const backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
@@ -86,4 +86,10 @@ describe('HTMLMarkdown — custom DSL', () => {
         const nestedDivInP = c.querySelector('p div');
         expect(nestedDivInP).toBeNull();
     });
+
+    it('--- renders a real semantic <hr> element', () => {
+        const c = renderMd('above\n\n---\n\nbelow');
+        const hr = c.querySelector('hr');
+        expect(hr).not.toBeNull();
+    });
 });

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.image.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.image.test.tsx
@@ -21,4 +21,26 @@ describe('HTMLMarkdown — image rendering', () => {
         expect(img?.getAttribute('alt')).toBe('a cat');
         expect(img?.getAttribute('src')).toBe('/cat.png');
     });
+
+    it('applies layout via classes; only pixel dimensions are inline (as CSS vars)', () => {
+        const { container } = render(
+            <HTMLMarkdown markdown={'![a cat](/cat.png =100x80|center)'} />
+        );
+        const row = container.querySelector('.md-image-row');
+        expect(row).not.toBeNull();
+        expect(row?.className).toContain('md-image-row--center');
+        // Row carries no inline layout styles — those live in CSS.
+        expect(row?.getAttribute('style')).toBeNull();
+
+        const frame = container.querySelector('.md-image-frame');
+        // The only inline styles are the dynamic dimension custom properties.
+        const frameStyle = frame?.getAttribute('style') ?? '';
+        expect(frameStyle).toContain('--md-image-max-w');
+        expect(frameStyle).toContain('--md-image-max-h');
+        expect(frameStyle).not.toContain('display');
+        expect(frameStyle).not.toContain('flex');
+
+        // The <img> itself has no inline style.
+        expect(container.querySelector('img')?.getAttribute('style')).toBeNull();
+    });
 });

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -51,3 +51,35 @@
     font-size: 1.1rem;
     color: var(--color-base-800);
 }
+
+/* Image DSL layout — literal class names emitted by the customImage remark
+   plugin, so they are declared :global here. Only per-image pixel dimensions
+   are passed inline (as --md-image-max-* custom properties). */
+:global(.md-image-row) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+:global(.md-image-row--left) {
+    justify-content: flex-start;
+}
+
+:global(.md-image-row--center) {
+    justify-content: center;
+}
+
+:global(.md-image-row--right) {
+    justify-content: flex-end;
+}
+
+:global(.md-image-frame) {
+    max-width: var(--md-image-max-w, 100%);
+    max-height: var(--md-image-max-h, 100%);
+}
+
+:global(.md-image) {
+    max-width: inherit;
+    max-height: inherit;
+}

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -18,37 +18,37 @@
     content: ">";
     position: absolute;
     top: 0;
-    left: -15px;
+    left: calc(-1 * var(--md-bullet-offset));
     font-weight: 600;
 }
 
 .h1 {
-    font-size: 3.8rem;
-    font-weight: 700;
+    font-size: var(--font-size-h1);
+    font-weight: var(--font-weight-heading);
 }
 
 .h2 {
-    font-size: 2.2rem;
-    font-weight: 700;
+    font-size: var(--font-size-h2);
+    font-weight: var(--font-weight-heading);
 }
 
 .h3 {
-    font-size: 1.8rem;
-    font-weight: 700;
+    font-size: var(--font-size-h3);
+    font-weight: var(--font-weight-heading);
 }
 
 .h4 {
-    font-size: 1.4rem;
-    font-weight: 700;
+    font-size: var(--font-size-h4);
+    font-weight: var(--font-weight-heading);
 }
 
 .h5 {
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: var(--font-size-h5);
+    font-weight: var(--font-weight-heading);
 }
 
 .h6 {
-    font-size: 1.1rem;
+    font-size: var(--font-size-h6);
     color: var(--color-base-800);
 }
 
@@ -59,7 +59,7 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 10px;
+    gap: var(--md-image-gap);
 }
 
 :global(.md-image-row--left) {

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -2,6 +2,7 @@
     margin: 1rem 0;
     background-color: var(--color-base-200);
     height: 1px;
+    border: none;
 }
 
 .ul {

--- a/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
@@ -2,7 +2,7 @@ import styles from './HTMLMarkdown.module.css';
 
 const HrMarkdown = ({ ...props }: React.HTMLAttributes<HTMLHRElement>) => {
     return (
-        <div {...props} className={styles.hr} />
+        <hr {...props} className={styles.hr} />
     )
 }
 

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
-import type { Element, RootContent } from 'hast'
-import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { markdownComponents } from './markdownComponents';
-import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
+import type { Element } from 'hast'
+import { useRenderedMarkdownChildren } from './renderMarkdownChildren';
 import Button from '../Button';
 import styles from './SpanMarkdown.module.css';
 
@@ -27,19 +25,7 @@ const variantClass: Record<SpanElementType, Record<SpanColorType, string>> = {
 
 const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
     const classes = useMemo(() => className?.split(" ") ?? [], [className]);
-    const contentJSXElementsFromAST = useMemo(() => {
-        const content = node?.children;
-        if (typeof content === 'string') return content;
-        const result = node?.children.map((element) => toJsxRuntime(element as RootContent, {
-            Fragment, jsx, jsxs, passNode: true, components: {
-                ...markdownComponents,
-                br: () => null,
-            },
-        }));
-        return result?.map((element, index) => (
-            <Fragment key={index}>{element}</Fragment>
-        ));
-    }, [node?.children]);
+    const contentJSXElementsFromAST = useRenderedMarkdownChildren(node);
     const spanElement = useMemo((): SpanElementType => {
         return classes.includes("highlight-area") ? "highlight-area" : "highlight-text";
     }, [classes]);

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
@@ -8,18 +8,25 @@ export const customBlockquote = () => {
         visit(tree, 'blockquote', (node: Blockquote) => {
             findAndReplace(node, [
                 /\[!([^[]+)\]\s?([a-z]*)/,
-                (fullText, variation, titleText, matchedNode) => {
-                    // To modfiy the parent node (Blockquote) of the matched text
-                    matchedNode.stack[matchedNode.stack.length - 3].data = {
+                (_fullText, variation, titleText) => {
+                    // Tag the blockquote itself with the callout variation as a
+                    // class. `node` is the blockquote we are visiting, so we no
+                    // longer need to walk the match's ancestor stack by index.
+                    node.data = {
                         hProperties: {
                             className: variation,
                         }
+                    };
+                    // If no title text is provided, drop the marker entirely.
+                    if (titleText === "") return null;
+                    // Promote the first child (the paragraph holding the title)
+                    // to a depth-5 heading.
+                    const titleParagraph = node.children[0];
+                    if (titleParagraph) {
+                        const asHeading = titleParagraph as unknown as { type: string; depth: number };
+                        asHeading.type = "heading";
+                        asHeading.depth = 5;
                     }
-                    // If no title text is provided
-                    if(titleText === "") return null;
-                    // Chnage the node (paragraph) type to heading
-                    matchedNode.stack[matchedNode.stack.length - 2].type = "heading";
-                    matchedNode.stack[matchedNode.stack.length - 2].depth = 5;
                     return {
                         type: 'text',
                         value: titleText

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
@@ -5,47 +5,28 @@ import { toString } from 'mdast-util-to-string'
 
 const imageRegex = /!\[([^\]]+)\]\(([^ ]+)\s?(?:=(?:(\d+)x(\d+)|(h|w)(\d+)))?(?:\|(center|left|right))?\)/;
 
-const imageNodeStyle: React.CSSProperties = ({
-    maxWidth: `inherit`,
-    maxHeight: `inherit`,
-});
-
-const imageWrapperNodeStyle = (width: number, height: number): React.CSSProperties => {
-    let finalWidth = "100%";
-    let finalHeight = "100%";
+// Only genuinely dynamic values (user-specified pixel dimensions) are emitted
+// inline, and only as CSS custom properties consumed by the stylesheet. All
+// static layout lives in HTMLMarkdown.module.css under :global(.md-image-*).
+const imageFrameVars = (width: number, height: number): string => {
+    let maxWidth = "100%";
+    let maxHeight = "100%";
     if (!width) {
-        finalHeight = `${height}px`;
+        maxHeight = `${height}px`;
     } else if (!height) {
-        finalWidth = `min(100%, ${width}px)`;
+        maxWidth = `min(100%, ${width}px)`;
     } else {
-        finalWidth = `min(100%, ${width}px)`;
-        finalHeight = `min(100%, ${height}px)`;
+        maxWidth = `min(100%, ${width}px)`;
+        maxHeight = `min(100%, ${height}px)`;
     }
-    return {
-        maxWidth: finalWidth,
-        maxHeight: finalHeight,
-    };
-}
+    return `--md-image-max-w: ${maxWidth}; --md-image-max-h: ${maxHeight}`;
+};
 
-const alignToFlex = (align: string): string => {
-    if (align === 'center') {
-        return 'center';
-    } else if (align === 'right') {
-        return 'flex-end';
-    } else {
-        return 'flex-start';
-    }
-}
-
-const imageContainerStyle = (align: string): React.CSSProperties => {
-    return {
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: alignToFlex(align),
-        alignItems: 'center',
-        gap: '10px',
-    }
-}
+const alignModifier = (align: string): string => {
+    if (align === 'center') return 'md-image-row--center';
+    if (align === 'right') return 'md-image-row--right';
+    return 'md-image-row--left';
+};
 
 export const customImage = () => {
     return function (tree: Nodes) {
@@ -78,10 +59,7 @@ export const customImage = () => {
                         alt: altText,
                         data: {
                             hProperties: {
-                                className: 'image',
-                                style: Object.entries(imageNodeStyle)
-                                    .map(([key, value]) => `${key}: ${value}`)
-                                    .join('; '),
+                                className: 'md-image',
                             }
                         }
                     };
@@ -91,10 +69,8 @@ export const customImage = () => {
                         data: {
                             hName: 'div',
                             hProperties: {
-                                className: 'image-container',
-                                style: Object.entries(imageWrapperNodeStyle(parseInt(width), parseInt(height)))
-                                    .map(([key, value]) => `${key}: ${value}`)
-                                    .join('; ')
+                                className: 'md-image-frame',
+                                style: imageFrameVars(parseInt(width), parseInt(height)),
                             }
                         }
                     });
@@ -103,10 +79,7 @@ export const customImage = () => {
                 currentNode.data = {
                     hName: 'div',
                     hProperties: {
-                        className: 'image',
-                        style: Object.entries(imageContainerStyle(align))
-                            .map(([key, value]) => `${key}: ${value}`)
-                            .join('; '),
+                        className: `md-image-row ${alignModifier(align)}`,
                     }
                 }
             }

--- a/react-frontend/src/components/HTMLMarkdown/renderMarkdownChildren.ts
+++ b/react-frontend/src/components/HTMLMarkdown/renderMarkdownChildren.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import type { Element, RootContent } from 'hast';
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
+import { markdownComponents } from './markdownComponents';
+
+// Re-renders a hast Element's children through the shared markdown component
+// map while suppressing <br>, so inline highlight/blockquote content stays on
+// a single line. Shared by SpanMarkdown and BlockquoteMarkdown to avoid
+// duplicating this recursive rendering block.
+export function useRenderedMarkdownChildren(node?: Element) {
+    return useMemo(() => {
+        return node?.children.map((element, index) =>
+            jsx(
+                Fragment,
+                {
+                    children: toJsxRuntime(element as RootContent, {
+                        Fragment,
+                        jsx,
+                        jsxs,
+                        passNode: true,
+                        components: {
+                            ...markdownComponents,
+                            br: () => null,
+                        },
+                    }),
+                },
+                index.toString(),
+            ),
+        );
+    }, [node?.children]);
+}

--- a/react-frontend/src/styles/tokens.css
+++ b/react-frontend/src/styles/tokens.css
@@ -56,4 +56,19 @@
   --space-4: 1.5rem;
   --space-5: 2rem;
   --space-6: 3rem;
+
+  /* Fluid heading type scale. Max values match the previously fixed markdown
+     heading sizes, so desktop rendering is unchanged; below ~1200px the
+     headings scale down smoothly instead of overflowing on small screens. */
+  --font-weight-heading: 700;
+  --font-size-h1: clamp(2.6rem, 1.75rem + 3.4vw, 3.8rem);
+  --font-size-h2: clamp(1.8rem, 1.45rem + 1.4vw, 2.2rem);
+  --font-size-h3: clamp(1.5rem, 1.3rem + 0.8vw, 1.8rem);
+  --font-size-h4: clamp(1.25rem, 1.15rem + 0.4vw, 1.4rem);
+  --font-size-h5: clamp(1.1rem, 1.05rem + 0.2vw, 1.2rem);
+  --font-size-h6: clamp(1.05rem, 1rem + 0.15vw, 1.1rem);
+
+  /* Markdown-specific spacing (previously hardcoded magic numbers) */
+  --md-bullet-offset: 15px;
+  --md-image-gap: 10px;
 }


### PR DESCRIPTION
Second batch of the markdown deep-review — the P2/P3 structural and design improvements (P1 correctness batch landed in #105).

## Changes
- **Dedupe recursive rendering (P2):** extracted the duplicated `toJsxRuntime` + `br`-suppression block from `SpanMarkdown`/`BlockquoteMarkdown` into a shared `useRenderedMarkdownChildren` hook.
- **Remove magic stack indices (P2):** `customBlockquote` no longer reaches into `matchedNode.stack[length-3]`/`[length-2]`; it uses the blockquote node from the visitor and its first child.
- **Image layout → CSS (P2):** `customImage` no longer serializes full inline style objects. Static layout now lives in `HTMLMarkdown.module.css` via `:global(.md-image-*)` rules; alignment is a modifier class; only user-specified pixel dimensions remain inline, as `--md-image-max-w/h` custom properties. Also fixes the previously backwards `image`/`image-container` class naming. **This completes the "no inline CSS" goal for the markdown layer.**
- **Semantic `<hr>` (P3):** `HrMarkdown` renders a real `<hr>` (border reset) instead of a styled `<div>`.
- **Fluid tokenized type scale (P3):** headings use a `clamp()` type scale exposed as design tokens; max sizes equal the previous fixed sizes so desktop is unchanged, narrow viewports scale down gracefully. Repeated `font-weight:700` consolidated into `--font-weight-heading`.
- **Tokenize magic numbers (P3):** list bullet `-15px` and image gap `10px` → `--md-bullet-offset` / `--md-image-gap`.

## Verification
- `eslint` 0 warnings, `tsc --noEmit` clean.
- **24/24 tests pass** (added image-CSS and hr regression tests).
- `vite build` OK; dev server verified after each change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>