### PR TITLE
chore: sync Development to main — inline-CSS elimination + markdown deep-review

### DIFF
--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -32,7 +32,6 @@
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "unist-util-visit": "^5.1.0",
-        "uuid": "^14.0.1",
         "web-vitals": "^5.3.0"
       },
       "devDependencies": {
@@ -6277,19 +6276,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -27,7 +27,6 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "unist-util-visit": "^5.1.0",
-    "uuid": "^14.0.1",
     "web-vitals": "^5.3.0"
   },
   "scripts": {

--- a/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/BlockquoteMarkdown.tsx
@@ -1,10 +1,7 @@
 import { useMemo } from 'react';
-import type { Element, RootContent } from 'hast'
+import type { Element } from 'hast'
 import MainSection from '../MainSection';
-import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
-import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { markdownComponents } from './markdownComponents';
-import { v4 as uuid } from 'uuid';
+import { useRenderedMarkdownChildren } from './renderMarkdownChildren';
 import { cx } from '../../utils/cx';
 import styles from './BlockquoteMarkdown.module.css';
 
@@ -16,17 +13,7 @@ type BlockquoteMarkdownProps = {
 
 
 const BlockquoteMarkdown = ({ node, className, ...props }: BlockquoteMarkdownProps) => {
-    const contentJSXElementsFromAST = useMemo(() => {
-        const content = node?.children.map((element) => toJsxRuntime(element as RootContent, {
-            Fragment, jsx, jsxs, passNode: true, components: {
-                ...markdownComponents,
-                br: () => null,
-            },
-        }));
-        return content?.map((element) => (
-            <Fragment key={uuid()}>{element}</Fragment>
-        ));
-    }, [node?.children]);
+    const contentJSXElementsFromAST = useRenderedMarkdownChildren(node);
 
     // By default it will be without-background and base color
     const backgroundType = useMemo((): BlockquoteElementType => className?.includes("highlight") ? "highlight-background" : "without-background", [className]);

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import HTMLMarkdown from './index';
+
+const renderMd = (markdown: string) =>
+    render(<HTMLMarkdown markdown={markdown} />).container;
+
+describe('HTMLMarkdown — custom DSL', () => {
+    it('[[text]] renders a button with the label', () => {
+        const c = renderMd('[[Click Me]]');
+        const btn = c.querySelector('button');
+        expect(btn).not.toBeNull();
+        expect(btn?.textContent).toBe('Click Me');
+    });
+
+    it('[gap] renders an inline <span> spacer, never a nested <p>', () => {
+        const c = renderMd('left[gap]right');
+        expect(c.querySelector('span')).not.toBeNull();
+        expect(c.querySelector('p p')).toBeNull();
+    });
+
+    it('[newline] renders an inline <span> spacer, never a nested <p>', () => {
+        const c = renderMd('top[newline]bottom');
+        expect(c.querySelector('span')).not.toBeNull();
+        expect(c.querySelector('p p')).toBeNull();
+    });
+
+    it('[center] applies text-align to the block', () => {
+        const c = renderMd('[center]hello');
+        expect(c.querySelector('[style*="text-align: center"]')).not.toBeNull();
+    });
+
+    it('# heading renders an <h1> with the heading style', () => {
+        const c = renderMd('# My Title');
+        const h1 = c.querySelector('h1');
+        expect(h1?.textContent).toBe('My Title');
+        expect(h1?.className).toMatch(/h1/);
+    });
+
+    it('- list renders custom <li> items', () => {
+        const c = renderMd('- first\n- second');
+        const items = c.querySelectorAll('li');
+        expect(items).toHaveLength(2);
+        expect(items[0].textContent).toBe('first');
+    });
+
+    it('**!text!** renders a secondary highlighted text span', () => {
+        const c = renderMd('**!hot!**');
+        const span = c.querySelector('[class*="highlightTextSecondary"]');
+        expect(span).not.toBeNull();
+        expect(span?.textContent).toBe('hot');
+    });
+
+    it('**-area-** renders a base highlight-area span', () => {
+        const c = renderMd('**-area-**');
+        const span = c.querySelector('[class*="highlightAreaBase"]');
+        expect(span).not.toBeNull();
+        expect(span?.textContent).toBe('area');
+    });
+
+    it('**!-area-!** renders a secondary highlight-area span', () => {
+        const c = renderMd('**!-wow-!**');
+        const span = c.querySelector('[class*="highlightAreaSecondary"]');
+        expect(span).not.toBeNull();
+        expect(span?.textContent).toBe('wow');
+    });
+
+    it('> [!variation] title blockquote renders title and body', () => {
+        const c = renderMd('> [!note] Heads up\n> body text');
+        expect(c.querySelector('[class*="blockquote"]')).not.toBeNull();
+        expect(c.textContent).toContain('Heads up');
+        expect(c.textContent).toContain('body text');
+    });
+
+    it('[[label|link]](url) renders a button with an icon', () => {
+        const c = renderMd('[[Google|link]](https://google.com)');
+        const btn = c.querySelector('button');
+        expect(btn?.textContent).toContain('Google');
+        expect(btn?.querySelector('svg')).not.toBeNull();
+    });
+
+    it('a standalone [text](url) link does not produce invalid <div> inside <p>', () => {
+        const c = renderMd('[Google](https://google.com)');
+        // AncherLinkMarkdown renders a block Header; it must not sit inside a <p>.
+        expect(c.textContent).toContain('Google');
+        const nestedDivInP = c.querySelector('p div');
+        expect(nestedDivInP).toBeNull();
+    });
+
+    it('--- renders a real semantic <hr> element', () => {
+        const c = renderMd('above\n\n---\n\nbelow');
+        const hr = c.querySelector('hr');
+        expect(hr).not.toBeNull();
+    });
+});

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.image.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.image.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import HTMLMarkdown from './index';
+
+describe('HTMLMarkdown — image rendering', () => {
+    it('does not nest block elements inside <p> (valid DOM)', () => {
+        const { container } = render(
+            <HTMLMarkdown markdown={'![cat](/cat.png =100x80|center)'} />
+        );
+        // The image and its wrappers must not live inside a <p>.
+        const img = container.querySelector('img');
+        expect(img).not.toBeNull();
+        expect(img?.closest('p')).toBeNull();
+    });
+
+    it('renders the image with its alt text and src', () => {
+        const { container } = render(
+            <HTMLMarkdown markdown={'![a cat](/cat.png =100x80|center)'} />
+        );
+        const img = container.querySelector('img');
+        expect(img?.getAttribute('alt')).toBe('a cat');
+        expect(img?.getAttribute('src')).toBe('/cat.png');
+    });
+
+    it('applies layout via classes; only pixel dimensions are inline (as CSS vars)', () => {
+        const { container } = render(
+            <HTMLMarkdown markdown={'![a cat](/cat.png =100x80|center)'} />
+        );
+        const row = container.querySelector('.md-image-row');
+        expect(row).not.toBeNull();
+        expect(row?.className).toContain('md-image-row--center');
+        // Row carries no inline layout styles — those live in CSS.
+        expect(row?.getAttribute('style')).toBeNull();
+
+        const frame = container.querySelector('.md-image-frame');
+        // The only inline styles are the dynamic dimension custom properties.
+        const frameStyle = frame?.getAttribute('style') ?? '';
+        expect(frameStyle).toContain('--md-image-max-w');
+        expect(frameStyle).toContain('--md-image-max-h');
+        expect(frameStyle).not.toContain('display');
+        expect(frameStyle).not.toContain('flex');
+
+        // The <img> itself has no inline style.
+        expect(container.querySelector('img')?.getAttribute('style')).toBeNull();
+    });
+});

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -2,6 +2,7 @@
     margin: 1rem 0;
     background-color: var(--color-base-200);
     height: 1px;
+    border: none;
 }
 
 .ul {
@@ -17,36 +18,68 @@
     content: ">";
     position: absolute;
     top: 0;
-    left: -15px;
+    left: calc(-1 * var(--md-bullet-offset));
     font-weight: 600;
 }
 
 .h1 {
-    font-size: 3.8rem;
-    font-weight: 700;
+    font-size: var(--font-size-h1);
+    font-weight: var(--font-weight-heading);
 }
 
 .h2 {
-    font-size: 2.2rem;
-    font-weight: 700;
+    font-size: var(--font-size-h2);
+    font-weight: var(--font-weight-heading);
 }
 
 .h3 {
-    font-size: 1.8rem;
-    font-weight: 700;
+    font-size: var(--font-size-h3);
+    font-weight: var(--font-weight-heading);
 }
 
 .h4 {
-    font-size: 1.4rem;
-    font-weight: 700;
+    font-size: var(--font-size-h4);
+    font-weight: var(--font-weight-heading);
 }
 
 .h5 {
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: var(--font-size-h5);
+    font-weight: var(--font-weight-heading);
 }
 
 .h6 {
-    font-size: 1.1rem;
+    font-size: var(--font-size-h6);
     color: var(--color-base-800);
+}
+
+/* Image DSL layout — literal class names emitted by the customImage remark
+   plugin, so they are declared :global here. Only per-image pixel dimensions
+   are passed inline (as --md-image-max-* custom properties). */
+:global(.md-image-row) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--md-image-gap);
+}
+
+:global(.md-image-row--left) {
+    justify-content: flex-start;
+}
+
+:global(.md-image-row--center) {
+    justify-content: center;
+}
+
+:global(.md-image-row--right) {
+    justify-content: flex-end;
+}
+
+:global(.md-image-frame) {
+    max-width: var(--md-image-max-w, 100%);
+    max-height: var(--md-image-max-h, 100%);
+}
+
+:global(.md-image) {
+    max-width: inherit;
+    max-height: inherit;
 }

--- a/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HrMarkdown.tsx
@@ -2,7 +2,7 @@ import styles from './HTMLMarkdown.module.css';
 
 const HrMarkdown = ({ ...props }: React.HTMLAttributes<HTMLHRElement>) => {
     return (
-        <div {...props} className={styles.hr} />
+        <hr {...props} className={styles.hr} />
     )
 }
 

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -1,10 +1,7 @@
 import { useMemo } from 'react';
-import type { Element, RootContent } from 'hast'
-import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { markdownComponents } from './markdownComponents';
-import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
+import type { Element } from 'hast'
+import { useRenderedMarkdownChildren } from './renderMarkdownChildren';
 import Button from '../Button';
-import { v4 as uuid } from 'uuid';
 import styles from './SpanMarkdown.module.css';
 
 
@@ -28,19 +25,7 @@ const variantClass: Record<SpanElementType, Record<SpanColorType, string>> = {
 
 const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
     const classes = useMemo(() => className?.split(" ") ?? [], [className]);
-    const contentJSXElementsFromAST = useMemo(() => {
-        const content = node?.children;
-        if (typeof content === 'string') return content;
-        const result = node?.children.map((element) => toJsxRuntime(element as RootContent, {
-            Fragment, jsx, jsxs, passNode: true, components: {
-                ...markdownComponents,
-                br: () => null,
-            },
-        }));
-        return result?.map((element) => (
-            <Fragment key={uuid()}>{element}</Fragment>
-        ));
-    }, [node?.children]);
+    const contentJSXElementsFromAST = useRenderedMarkdownChildren(node);
     const spanElement = useMemo((): SpanElementType => {
         return classes.includes("highlight-area") ? "highlight-area" : "highlight-text";
     }, [classes]);

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customBlockquote.ts
@@ -8,18 +8,25 @@ export const customBlockquote = () => {
         visit(tree, 'blockquote', (node: Blockquote) => {
             findAndReplace(node, [
                 /\[!([^[]+)\]\s?([a-z]*)/,
-                (fullText, variation, titleText, matchedNode) => {
-                    // To modfiy the parent node (Blockquote) of the matched text
-                    matchedNode.stack[matchedNode.stack.length - 3].data = {
+                (_fullText, variation, titleText) => {
+                    // Tag the blockquote itself with the callout variation as a
+                    // class. `node` is the blockquote we are visiting, so we no
+                    // longer need to walk the match's ancestor stack by index.
+                    node.data = {
                         hProperties: {
                             className: variation,
                         }
+                    };
+                    // If no title text is provided, drop the marker entirely.
+                    if (titleText === "") return null;
+                    // Promote the first child (the paragraph holding the title)
+                    // to a depth-5 heading.
+                    const titleParagraph = node.children[0];
+                    if (titleParagraph) {
+                        const asHeading = titleParagraph as unknown as { type: string; depth: number };
+                        asHeading.type = "heading";
+                        asHeading.depth = 5;
                     }
-                    // If no title text is provided
-                    if(titleText === "") return null;
-                    // Chnage the node (paragraph) type to heading
-                    matchedNode.stack[matchedNode.stack.length - 2].type = "heading";
-                    matchedNode.stack[matchedNode.stack.length - 2].depth = 5;
                     return {
                         type: 'text',
                         value: titleText

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customImage.ts
@@ -5,47 +5,28 @@ import { toString } from 'mdast-util-to-string'
 
 const imageRegex = /!\[([^\]]+)\]\(([^ ]+)\s?(?:=(?:(\d+)x(\d+)|(h|w)(\d+)))?(?:\|(center|left|right))?\)/;
 
-const imageNodeStyle: React.CSSProperties = ({
-    maxWidth: `inherit`,
-    maxHeight: `inherit`,
-});
-
-const imageWrapperNodeStyle = (width: number, height: number): React.CSSProperties => {
-    let finalWidth = "100%";
-    let finalHeight = "100%";
+// Only genuinely dynamic values (user-specified pixel dimensions) are emitted
+// inline, and only as CSS custom properties consumed by the stylesheet. All
+// static layout lives in HTMLMarkdown.module.css under :global(.md-image-*).
+const imageFrameVars = (width: number, height: number): string => {
+    let maxWidth = "100%";
+    let maxHeight = "100%";
     if (!width) {
-        finalHeight = `${height}px`;
+        maxHeight = `${height}px`;
     } else if (!height) {
-        finalWidth = `min(100%, ${width}px)`;
+        maxWidth = `min(100%, ${width}px)`;
     } else {
-        finalWidth = `min(100%, ${width}px)`;
-        finalHeight = `min(100%, ${height}px)`;
+        maxWidth = `min(100%, ${width}px)`;
+        maxHeight = `min(100%, ${height}px)`;
     }
-    return {
-        maxWidth: finalWidth,
-        maxHeight: finalHeight,
-    };
-}
+    return `--md-image-max-w: ${maxWidth}; --md-image-max-h: ${maxHeight}`;
+};
 
-const alignToFlex = (align: string): string => {
-    if (align === 'center') {
-        return 'center';
-    } else if (align === 'right') {
-        return 'flex-end';
-    } else {
-        return 'flex-start';
-    }
-}
-
-const imageContainerStyle = (align: string): React.CSSProperties => {
-    return {
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: alignToFlex(align),
-        alignItems: 'center',
-        gap: '10px',
-    }
-}
+const alignModifier = (align: string): string => {
+    if (align === 'center') return 'md-image-row--center';
+    if (align === 'right') return 'md-image-row--right';
+    return 'md-image-row--left';
+};
 
 export const customImage = () => {
     return function (tree: Nodes) {
@@ -78,10 +59,7 @@ export const customImage = () => {
                         alt: altText,
                         data: {
                             hProperties: {
-                                className: 'image',
-                                style: Object.entries(imageNodeStyle)
-                                    .map(([key, value]) => `${key}: ${value}`)
-                                    .join('; '),
+                                className: 'md-image',
                             }
                         }
                     };
@@ -89,22 +67,19 @@ export const customImage = () => {
                         type: 'paragraph',
                         children: [imageNode],
                         data: {
+                            hName: 'div',
                             hProperties: {
-                                className: 'image-container',
-                                style: Object.entries(imageWrapperNodeStyle(parseInt(width), parseInt(height)))
-                                    .map(([key, value]) => `${key}: ${value}`)
-                                    .join('; ')
+                                className: 'md-image-frame',
+                                style: imageFrameVars(parseInt(width), parseInt(height)),
                             }
                         }
                     });
                 }
                 currentNode.children = imageNodes;
                 currentNode.data = {
+                    hName: 'div',
                     hProperties: {
-                        className: 'image',
-                        style: Object.entries(imageContainerStyle(align))
-                            .map(([key, value]) => `${key}: ${value}`)
-                            .join('; '),
+                        className: `md-image-row ${alignModifier(align)}`,
                     }
                 }
             }

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customLink.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customLink.ts
@@ -1,0 +1,22 @@
+import { visit } from 'unist-util-visit';
+import { Nodes, Parent } from 'mdast'
+
+/**
+ * A standalone link (`[text](url)`) is rendered by AncherLinkMarkdown as a
+ * block-level Header/Button. react-markdown wraps it in a <p>, producing an
+ * invalid <p><div>…</div></p>. When a paragraph contains only a link, render
+ * the paragraph as a <div> so the block content nests validly.
+ */
+export const customLink = () => {
+    return function (tree: Nodes) {
+        visit(tree, 'paragraph', (node: Nodes) => {
+            const paragraph = node as Parent;
+            if (paragraph.children.length === 1 && paragraph.children[0].type === 'link') {
+                paragraph.data = {
+                    ...(paragraph.data ?? {}),
+                    hName: 'div',
+                };
+            }
+        });
+    };
+};

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/index.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/index.ts
@@ -2,3 +2,4 @@ export { customText } from './customText';
 export { customBlockquote } from './customBlockquote';
 export { customHighlightText } from './customHighlightText';
 export { customImage } from './customImage';
+export { customLink } from './customLink';

--- a/react-frontend/src/components/HTMLMarkdown/index.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/index.tsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks'
 import { markdownComponents } from './markdownComponents';
-import { customBlockquote, customHighlightText, customImage, customText } from './customPlugins';
+import { customBlockquote, customHighlightText, customImage, customLink, customText } from './customPlugins';
 
 type Props = {
     readonly markdown: string
@@ -15,6 +15,7 @@ function HTMLMarkdown({ markdown }: Props) {
                 remarkGfm,
                 remarkBreaks,
                 customImage,
+                customLink,
                 customText,
                 customHighlightText,
                 customBlockquote

--- a/react-frontend/src/components/HTMLMarkdown/renderMarkdownChildren.ts
+++ b/react-frontend/src/components/HTMLMarkdown/renderMarkdownChildren.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import type { Element, RootContent } from 'hast';
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
+import { markdownComponents } from './markdownComponents';
+
+// Re-renders a hast Element's children through the shared markdown component
+// map while suppressing <br>, so inline highlight/blockquote content stays on
+// a single line. Shared by SpanMarkdown and BlockquoteMarkdown to avoid
+// duplicating this recursive rendering block.
+export function useRenderedMarkdownChildren(node?: Element) {
+    return useMemo(() => {
+        return node?.children.map((element, index) =>
+            jsx(
+                Fragment,
+                {
+                    children: toJsxRuntime(element as RootContent, {
+                        Fragment,
+                        jsx,
+                        jsxs,
+                        passNode: true,
+                        components: {
+                            ...markdownComponents,
+                            br: () => null,
+                        },
+                    }),
+                },
+                index.toString(),
+            ),
+        );
+    }, [node?.children]);
+}

--- a/react-frontend/src/components/MainSection/Header.module.css
+++ b/react-frontend/src/components/MainSection/Header.module.css
@@ -2,6 +2,15 @@
     display: inline;
 }
 
+.titleText {
+    display: inline;
+    margin-right: 0.5rem;
+}
+
+.iconText {
+    display: inline-block;
+}
+
 .headerText {
     display: inline;
 }

--- a/react-frontend/src/components/MainSection/Header.tsx
+++ b/react-frontend/src/components/MainSection/Header.tsx
@@ -5,9 +5,6 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { cx } from '../../utils/cx';
 import styles from './Header.module.css';
 
-const titleTextStyle = { display: 'inline', marginRight: '0.5rem' } as const;
-const iconTextStyle = { display: 'inline-block' } as const;
-
 type HeaderProps = {
     readonly title: string,
     readonly link?: string,
@@ -27,14 +24,14 @@ export default function Header({ title, link, subtitle }: HeaderProps) {
                 <Text
                     variant={"h3"}
                     onClick={link ? headerOnCLickHandler : undefined}
-                    style={titleTextStyle}>
+                    className={styles.titleText}>
                     <span className={cx(styles.headerText, link && styles.pointer)}>{title}</span>
                 </Text>
                 {link && (
                     <Text
                         variant={"h3"}
                         onClick={headerOnCLickHandler}
-                        style={iconTextStyle}>
+                        className={styles.iconText}>
                         <span className={cx(styles.linkText, styles.pointer)}>
                             <ExternalLinkIcon />
                         </span>

--- a/react-frontend/src/components/Navbar/Links/LinkButton.module.css
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.module.css
@@ -1,3 +1,15 @@
-.link {
+/* Self-compound (.link.link) raises specificity to 0-2-0 so these token-based
+   colours win over Button's single-class .button/.ghost rules regardless of
+   CSS bundle order — without resorting to inline styles or !important. */
+.link.link {
     font-weight: 500;
+    background-color: transparent;
+    color: var(--color-base-400);
+    opacity: 0.9;
+}
+
+.link.active {
+    background-color: var(--color-base-200);
+    color: var(--color-base-800);
+    opacity: 1;
 }

--- a/react-frontend/src/components/Navbar/Links/LinkButton.tsx
+++ b/react-frontend/src/components/Navbar/Links/LinkButton.tsx
@@ -1,7 +1,8 @@
 import Button from '../../Button'
 import { PortfolioPathes } from '../../../Types';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
+import { cx } from '../../../utils/cx';
 import styles from './LinkButton.module.css';
 
 type LinkButtonProps = {
@@ -12,23 +13,12 @@ type LinkButtonProps = {
 
 function LinkButton({ path, pageName, onClick }: LinkButtonProps) {
     const navigate = useNavigate();
-    const active = useMatch(`/${path}`);
-    // Active/inactive colours depend on the current route, so they stay as
-    // token-based inline styles; the ghost variant strips the default border/shadow.
-    const linkButtonStyle = useMemo(() => {
-        const linkActive = active !== null;
-        return {
-            backgroundColor: linkActive ? 'var(--color-base-200)' : 'transparent',
-            color: linkActive ? 'var(--color-base-800)' : 'var(--color-base-400)',
-            opacity: linkActive ? 1 : 0.9,
-        };
-    }, [active]);
+    const active = useMatch(`/${path}`) !== null;
 
     return (
         <Button
             variant="ghost"
-            className={styles.link}
-            style={linkButtonStyle}
+            className={cx(styles.link, active && styles.active)}
             pointer={true}
             size='md'
             onClick={() => {

--- a/react-frontend/src/components/Text/index.tsx
+++ b/react-frontend/src/components/Text/index.tsx
@@ -10,12 +10,13 @@ const variantTags = {
 
 type TextProps = {
     readonly variant?: keyof typeof variantTags;
+    readonly className?: string;
     readonly style?: CSSProperties;
     readonly onClick?: () => void;
     readonly children: ReactNode;
 };
 
-export default function Text({ variant = 'body', style, onClick, children }: TextProps) {
+export default function Text({ variant = 'body', className, style, onClick, children }: TextProps) {
     const Tag = variantTags[variant];
 
     // Only expose keyboard/focus affordances when the node is actually interactive.
@@ -34,7 +35,7 @@ export default function Text({ variant = 'body', style, onClick, children }: Tex
         : {};
 
     return (
-        <Tag style={style} {...interactiveProps}>
+        <Tag className={className} style={style} {...interactiveProps}>
             {children}
         </Tag>
     );

--- a/react-frontend/src/styles/tokens.css
+++ b/react-frontend/src/styles/tokens.css
@@ -56,4 +56,19 @@
   --space-4: 1.5rem;
   --space-5: 2rem;
   --space-6: 3rem;
+
+  /* Fluid heading type scale. Max values match the previously fixed markdown
+     heading sizes, so desktop rendering is unchanged; below ~1200px the
+     headings scale down smoothly instead of overflowing on small screens. */
+  --font-weight-heading: 700;
+  --font-size-h1: clamp(2.6rem, 1.75rem + 3.4vw, 3.8rem);
+  --font-size-h2: clamp(1.8rem, 1.45rem + 1.4vw, 2.2rem);
+  --font-size-h3: clamp(1.5rem, 1.3rem + 0.8vw, 1.8rem);
+  --font-size-h4: clamp(1.25rem, 1.15rem + 0.4vw, 1.4rem);
+  --font-size-h5: clamp(1.1rem, 1.05rem + 0.2vw, 1.2rem);
+  --font-size-h6: clamp(1.05rem, 1rem + 0.15vw, 1.1rem);
+
+  /* Markdown-specific spacing (previously hardcoded magic numbers) */
+  --md-bullet-offset: 15px;
+  --md-image-gap: 10px;
 }


### PR DESCRIPTION
Batches PRs #104, #105, #106 into production in a single deploy.

- **#104** Eliminate remaining inline CSS (Header static styles, LinkButton active-state).
- **#105** Markdown P1 correctness (invalid `<p>` nesting for images + links, stable keys) + first DSL/image test suite.
- **#106** Markdown P2/P3: dedupe recursive renderer into a shared hook, remove `customBlockquote` magic stack indices, move image layout into CSS (`:global(.md-image-*)` + custom-property dimensions), semantic `<hr>`, fluid tokenized heading scale, tokenized magic numbers.

Content-identical to Development. 24/24 tests pass; eslint/tsc/build clean.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>