### PR TITLE
refactor(markdown): eliminate last inline CSS (customText spacers + alignment)

### DIFF
--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.dsl.test.tsx
@@ -13,21 +13,26 @@ describe('HTMLMarkdown — custom DSL', () => {
         expect(btn?.textContent).toBe('Click Me');
     });
 
-    it('[gap] renders an inline <span> spacer, never a nested <p>', () => {
+    it('[gap] renders an inline <span> spacer via class, never a nested <p>', () => {
         const c = renderMd('left[gap]right');
-        expect(c.querySelector('span')).not.toBeNull();
+        const gap = c.querySelector('span.md-gap');
+        expect(gap).not.toBeNull();
+        expect(gap?.getAttribute('style')).toBeNull();
         expect(c.querySelector('p p')).toBeNull();
     });
 
-    it('[newline] renders an inline <span> spacer, never a nested <p>', () => {
+    it('[newline] renders an inline <span> spacer via class, never a nested <p>', () => {
         const c = renderMd('top[newline]bottom');
-        expect(c.querySelector('span')).not.toBeNull();
+        const nl = c.querySelector('span.md-newline');
+        expect(nl).not.toBeNull();
+        expect(nl?.getAttribute('style')).toBeNull();
         expect(c.querySelector('p p')).toBeNull();
     });
 
-    it('[center] applies text-align to the block', () => {
+    it('[center] applies alignment via a class, not inline style', () => {
         const c = renderMd('[center]hello');
-        expect(c.querySelector('[style*="text-align: center"]')).not.toBeNull();
+        expect(c.querySelector('.md-align-center')).not.toBeNull();
+        expect(c.querySelector('[style*="text-align"]')).toBeNull();
     });
 
     it('# heading renders an <h1> with the heading style', () => {

--- a/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
+++ b/react-frontend/src/components/HTMLMarkdown/HTMLMarkdown.module.css
@@ -83,3 +83,27 @@
     max-width: inherit;
     max-height: inherit;
 }
+
+/* Inline text-DSL spacers and alignment — literal class names emitted by the
+   customText capture plugins. */
+:global(.md-gap) {
+    display: inline-block;
+    margin: 0 var(--space-3) var(--space-3) 0;
+}
+
+:global(.md-newline) {
+    display: grid;
+    margin: var(--space-2) 0;
+}
+
+:global(.md-align-left) {
+    text-align: left;
+}
+
+:global(.md-align-center) {
+    text-align: center;
+}
+
+:global(.md-align-right) {
+    text-align: right;
+}

--- a/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
+++ b/react-frontend/src/components/HTMLMarkdown/SpanMarkdown.tsx
@@ -33,6 +33,12 @@ const SpanMarkdown = ({ node, className, ...props }: SpanMarkdownProps) => {
         return classes.includes("secondary") ? "secondary" : "base";
     }, [classes]);
 
+    // Inline spacers (`[gap]` / `[newline]`) carry a layout-only class and no
+    // content; render a plain span so its :global class controls the spacing.
+    if (classes.includes("md-gap") || classes.includes("md-newline")) {
+        return <span {...props} className={className} />;
+    }
+
     // `[[Button]]`
     if (classes.includes("button")) {
         return (

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureGap.ts
@@ -10,7 +10,7 @@ export const captureGap = (_node: Node): customType => ({
         data: {
             hName: 'span',
             hProperties: {
-                style: "margin: 0 1rem 1rem 0; display: inline-block;"
+                className: 'md-gap'
             }
         }
     } as unknown as PhrasingContent)

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureNewline.ts
@@ -11,7 +11,7 @@ export const captureNewline = (_node: Node): customType => ({
             data: {
                 hName: 'span',
                 hProperties: {
-                    style: "margin: 0.5rem 0; display: grid;"
+                    className: 'md-newline'
                 }
             }
         } as unknown as PhrasingContent)

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureTextDirection.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/captureTextDirection.ts
@@ -3,10 +3,10 @@ import type { customType } from '.'
 
 export const captureTextDirection = (node: Node): customType => ({
     regex: /\[(center|left|right)\]/,
-    callback: (fullText: string, align: string) => {
+    callback: (_fullText: string, align: string) => {
         node.data = {
             hProperties: {
-                style: "text-align: " + align
+                className: `md-align-${align}`
             }
         }
         return null;

--- a/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/index.ts
+++ b/react-frontend/src/components/HTMLMarkdown/customPlugins/customText/index.ts
@@ -20,8 +20,9 @@ export const customText = () => {
                     captureGap(node as Nodes)
                 ]
                 customTextPlugins.forEach(({ regex, callback }) => {
-                    while (true) {
-                        let exists = false;
+                    let exists = true;
+                    while (exists) {
+                        exists = false;
                         findAndReplace(node as Nodes, [
                             regex,
                             (...args) => {
@@ -29,9 +30,6 @@ export const customText = () => {
                                 return callback(...args)
                             },
                         ]);
-                        if (!exists) {
-                            break;
-                        }
                     }
                 })
             }


### PR DESCRIPTION
Follow-up that closes out the "no inline CSS" goal — a project-wide sweep found the `customText` spacer/alignment plugins were still injecting inline styles.

## Changes
- `captureGap` / `captureNewline`: static inline styles → `:global(.md-gap)` / `:global(.md-newline)` classes using spacing tokens (visually identical: `1rem`/`0.5rem` map to `--space-3`/`--space-2`).
- `captureTextDirection`: inline `text-align` → `md-align-{left,center,right}` modifier classes.
- `SpanMarkdown`: now passes spacer classes through instead of overriding `className` with a highlight variant (the old inline `style` only survived because it was spread via `{...props}`).
- Tidied the `customText` `while(true) { let exists }` loop into a clear `while(exists)` form.

## Why
A frontend-wide grep for `style=` confirms every remaining usage is legitimate: `style={style}` passthrough props, react-spring animations, and dynamic-value bridges (CSS custom properties / `color-mix`). This was the **last static inline-style violation**.

## Verification
- eslint 0 / `tsc` clean / **24/24 tests** (strengthened gap/newline/center tests to assert class presence + absence of inline style) / `vite build` OK / dev server 200.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>