### PR TITLE
chore(sanity): record deployed Studio appId for non-interactive deploys

### DIFF
--- a/sanity-backend/sanity.cli.ts
+++ b/sanity-backend/sanity.cli.ts
@@ -6,5 +6,8 @@ export default defineCliConfig({
     // Same override as sanity.config.ts — keep the CLI targeting the same
     // dataset as Studio when SANITY_STUDIO_DATASET is set locally.
     dataset: process.env.SANITY_STUDIO_DATASET || 'production'
-  }
+  },
+  deployment: {
+    appId: '09fccba0f2ed1132428ca4af',
+  },
 })


### PR DESCRIPTION
Adds the `deployment.appId` returned by `sanity deploy` (after deploying the updated schema to https://shawkyebrahim.sanity.studio/) so future deploys don't need an interactive prompt for the application id.