### PR TITLE
Add Star Border CTA effect and Glass Surface popup treatment

### DIFF
--- a/react-frontend/src/components/BlurBackground.module.css
+++ b/react-frontend/src/components/BlurBackground.module.css
@@ -1,9 +1,26 @@
+/* Zero-dependency hand-port of react-bits' GlassSurface "fallback" style
+   (frosted panel, no SVG liquid-distortion filter): extra saturation/brightness
+   on the backdrop blur plus subtle inset highlights along the top/bottom edges
+   give the panel a glassy sheen instead of a flat blurred color. */
 .blur {
     z-index: -1;
     position: absolute;
-    backdrop-filter: blur(8px);
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
+    border-radius: inherit;
+    backdrop-filter: blur(14px) saturate(1.8) brightness(1.08);
+    -webkit-backdrop-filter: blur(14px) saturate(1.8) brightness(1.08);
+    border: 1px solid hsla(0, 0%, 100%, 0.18);
+    box-shadow:
+        inset 0 1px 0 0 hsla(0, 0%, 100%, 0.25),
+        inset 0 -1px 0 0 hsla(0, 0%, 100%, 0.06);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+    .blur {
+        border: none;
+        box-shadow: none;
+    }
 }

--- a/react-frontend/src/components/BlurBackground.tsx
+++ b/react-frontend/src/components/BlurBackground.tsx
@@ -8,6 +8,6 @@ export default function BlurBackground({ backgroundColor }: BlurBackgroundProps)
     return (
         <div
             className={styles.blur}
-            style={{ backgroundColor: `color-mix(in srgb, ${backgroundColor} 80%, transparent)` }} />
+            style={{ backgroundColor: `color-mix(in srgb, ${backgroundColor} 65%, transparent)` }} />
     )
 }

--- a/react-frontend/src/components/RichContent/ButtonLink.module.css
+++ b/react-frontend/src/components/RichContent/ButtonLink.module.css
@@ -3,4 +3,6 @@
    browser-default underline that .button never had to account for. */
 .noUnderline {
     text-decoration: none;
+    position: relative;
+    z-index: 1;
 }

--- a/react-frontend/src/components/RichContent/ButtonLink.tsx
+++ b/react-frontend/src/components/RichContent/ButtonLink.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLink, faFileAlt } from '@fortawesome/free-solid-svg-icons';
 import { cx } from '../../utils/cx';
+import StarBorder from '../StarBorder';
 import buttonStyles from '../Button/Button.module.css';
 import styles from './ButtonLink.module.css';
 
@@ -14,17 +15,22 @@ type ButtonLinkProps = {
 // Renders `[[Text|doc]](url)` / `[[Text]](url)` button-links as a real
 // anchor styled like Button, rather than a <button> driven by an onClick
 // window.open — real link semantics are keyboard/middle-click/screen-reader
-// friendly in a way a synthetic button never is.
+// friendly in a way a synthetic button never is. Wrapped in StarBorder so
+// these standalone CTAs (e.g. "See My Resume") get an animated glowing
+// border traveling around them, drawing the eye without any new dependency.
 export default function ButtonLink({ href, icon = 'link', text, size = 'md' }: ButtonLinkProps) {
     return (
-        <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cx(buttonStyles.button, buttonStyles[size], buttonStyles.pointer, styles.noUnderline)}
-        >
-            <FontAwesomeIcon icon={icon === 'doc' ? faFileAlt : faLink} />
-            {text}
-        </a>
+        <StarBorder>
+            <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cx(buttonStyles.button, buttonStyles[size], buttonStyles.pointer, styles.noUnderline)}
+            >
+                <FontAwesomeIcon icon={icon === 'doc' ? faFileAlt : faLink} />
+                {text}
+            </a>
+        </StarBorder>
     );
 }
+

--- a/react-frontend/src/components/StarBorder/StarBorder.module.css
+++ b/react-frontend/src/components/StarBorder/StarBorder.module.css
@@ -1,0 +1,60 @@
+.wrapper {
+    display: inline-block;
+    position: relative;
+    border-radius: calc(var(--radius) + 3px);
+    overflow: hidden;
+    padding: 2px;
+}
+
+.gradientBottom,
+.gradientTop {
+    position: absolute;
+    width: 300%;
+    height: 50%;
+    opacity: 0.65;
+    border-radius: 50%;
+    z-index: 0;
+    background: radial-gradient(circle, var(--color-secondary-500), transparent 10%);
+}
+
+.gradientBottom {
+    bottom: -12px;
+    right: -250%;
+    animation: star-movement-bottom 5s linear infinite alternate;
+}
+
+.gradientTop {
+    top: -12px;
+    left: -250%;
+    animation: star-movement-top 5s linear infinite alternate;
+}
+
+@keyframes star-movement-bottom {
+    0% {
+        transform: translate(0%, 0%);
+        opacity: 1;
+    }
+    100% {
+        transform: translate(-100%, 0%);
+        opacity: 0;
+    }
+}
+
+@keyframes star-movement-top {
+    0% {
+        transform: translate(0%, 0%);
+        opacity: 1;
+    }
+    100% {
+        transform: translate(100%, 0%);
+        opacity: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .gradientBottom,
+    .gradientTop {
+        animation: none;
+        opacity: 0.35;
+    }
+}

--- a/react-frontend/src/components/StarBorder/index.tsx
+++ b/react-frontend/src/components/StarBorder/index.tsx
@@ -1,0 +1,23 @@
+import { cx } from '../../utils/cx';
+import styles from './StarBorder.module.css';
+
+type StarBorderProps = {
+    readonly className?: string;
+    readonly children: React.ReactNode;
+};
+
+// Zero-dependency, CSS-only port of react-bits' Star Border: two blurred
+// radial-gradient "comets" orbit behind the content on an infinite loop,
+// only ever visible through a thin padding gap — reading as an animated
+// glowing border traveling around the button. `children` must render its
+// own opaque background/border-radius (e.g. Button/ButtonLink already do)
+// so it fully occludes the comets except at that thin gap.
+export default function StarBorder({ className, children }: StarBorderProps) {
+    return (
+        <span className={cx(styles.wrapper, className)}>
+            <span className={styles.gradientBottom} aria-hidden="true" />
+            <span className={styles.gradientTop} aria-hidden="true" />
+            {children}
+        </span>
+    );
+}


### PR DESCRIPTION
Two zero-dependency, hand-ported react-bits-style effects:

- **Star Border**: animated glowing border on the CTA buttons (See My Resume / View Contact Page), using two counter-rotating radial-gradient comets revealed behind a thin gap. Respects prefers-reduced-motion.
- **Glass Surface**: richer frosted-glass treatment for popup/overlay panels (mobile nav popup, project card hover overlay) via the shared BlurBackground component - added saturation/brightness to the backdrop blur and subtle glass-edge highlights, lightened background tint for a more see-through look.

Both validated with tsc, eslint, vitest (39 tests), and production build on top of latest Development.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>