### PR TITLE
Add gradient + dot-grid texture to section containers

### DIFF
--- a/react-frontend/src/styles/surfaces.module.css
+++ b/react-frontend/src/styles/surfaces.module.css
@@ -5,11 +5,32 @@
     gap: 1rem;
     padding: 1rem;
     place-items: stretch;
+    position: relative;
     background-color: var(--color-base-50);
     background-image: linear-gradient(135deg, var(--color-base-100) 0%, var(--color-base-0) 50%, var(--color-base-100) 100%);
     border: var(--border);
     border-radius: var(--radius);
     box-shadow: var(--shadow);
+}
+
+/* Repeating low-opacity dot-grid pattern (pure CSS radial-gradient, no image
+   asset) layered over the gradient fill for a bit of "graph paper" texture.
+   Absolutely positioned so it stays out of the flex flow. */
+.container::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    border-radius: inherit;
+    background-image: radial-gradient(var(--color-base-800) 1px, transparent 1px);
+    background-size: 16px 16px;
+    opacity: 0.08;
+}
+
+.container > * {
+    position: relative;
+    z-index: 1;
 }
 
 .boxing {

--- a/react-frontend/src/styles/surfaces.module.css
+++ b/react-frontend/src/styles/surfaces.module.css
@@ -6,6 +6,7 @@
     padding: 1rem;
     place-items: stretch;
     background-color: var(--color-base-50);
+    background-image: linear-gradient(135deg, var(--color-base-100) 0%, var(--color-base-0) 50%, var(--color-base-100) 100%);
     border: var(--border);
     border-radius: var(--radius);
     box-shadow: var(--shadow);


### PR DESCRIPTION
Replaces the flat solid --color-base-50 fill on section cards (About, Skills, Experience, Education, Contacts, Project cards) with:

- A diagonal dark-light-dark gradient (base-100 -> base-0 -> base-100) for a bit of depth/sheen.
- A subtle (8% opacity) repeating dot-grid pattern layered on top for graph-paper texture.

Tried and rejected alternatives (grain/noise texture, full Glass Surface transparency) before landing on this combo.

Validated with tsc, eslint, vitest (39 tests), and production build on top of latest Development.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>