### PR TITLE
feat(hub): production visibility flag for Hub entries

### DIFF
--- a/react-frontend/pages/+Layout.tsx
+++ b/react-frontend/pages/+Layout.tsx
@@ -13,6 +13,8 @@ import Loader from '../src/components/Loader';
 import ErrorBoundary from '../src/components/ErrorBoundary';
 import ShapeGridBackground from '../src/components/ShapeGridBackground';
 import ClickSpark from '../src/components/ClickSpark';
+import PreviewProvider from '../src/contexts/PreviewContext';
+import PreviewBanner from '../src/components/PreviewBanner';
 import { themeStyle, kindAmbient, KIND_ACCENT } from '../src/containers/Hub/kindAccent';
 import type { HubEntryKind } from '../src/Types';
 import '../src/styles/tokens.css';
@@ -33,26 +35,29 @@ export default function Layout({ children }: Readonly<{ children: ReactNode }>) 
 
     return (
         <ThemeContext>
-            <div className={styles.page} style={themeVars}>
-                <ShapeGridBackground hoverColor={ambient?.gridHover} />
-                <ClickSpark color={ambient?.spark} />
-                <a className={styles.skipLink} href="#main-content">Skip to main content</a>
-                <div className={styles.inner}>
-                    <Suspense fallback={<Loader />}>
-                        <header className={styles.banner}>
-                            <Navbar
-                                readingProgress
-                                progressAccent={kind ? (accentColor ?? KIND_ACCENT[kind]) : undefined}
-                            />
-                        </header>
-                        <main id="main-content" tabIndex={-1} className={styles.main}>
-                            <ErrorBoundary>
-                                {children}
-                            </ErrorBoundary>
-                        </main>
-                    </Suspense>
+            <PreviewProvider>
+                <div className={styles.page} style={themeVars}>
+                    <ShapeGridBackground hoverColor={ambient?.gridHover} />
+                    <ClickSpark color={ambient?.spark} />
+                    <a className={styles.skipLink} href="#main-content">Skip to main content</a>
+                    <div className={styles.inner}>
+                        <Suspense fallback={<Loader />}>
+                            <header className={styles.banner}>
+                                <Navbar
+                                    readingProgress
+                                    progressAccent={kind ? (accentColor ?? KIND_ACCENT[kind]) : undefined}
+                                />
+                            </header>
+                            <main id="main-content" tabIndex={-1} className={styles.main}>
+                                <ErrorBoundary>
+                                    {children}
+                                </ErrorBoundary>
+                            </main>
+                        </Suspense>
+                    </div>
+                    <PreviewBanner />
                 </div>
-            </div>
+            </PreviewProvider>
             <Analytics />
         </ThemeContext>
     );

--- a/react-frontend/pages/hub/+Page.tsx
+++ b/react-frontend/pages/hub/+Page.tsx
@@ -4,6 +4,8 @@ import Title from '../../src/containers/Title';
 import RichContent from '../../src/components/RichContent';
 import CategoryFilters from '../../src/containers/Hub/CategoryFilters';
 import Grid from '../../src/containers/Hub/Grid';
+import { filterVisible } from '../../src/containers/Hub/visibility';
+import { useIsPreview } from '../../src/contexts/PreviewContext';
 import { cx } from '../../src/utils/cx';
 import type { HubIndexData } from './+data';
 import section from '../../src/styles/section.module.css';
@@ -12,6 +14,8 @@ import lede from '../../src/styles/lede.module.css';
 
 function Hub() {
     const { page, entries, categories } = useData<HubIndexData>();
+    const isPreview = useIsPreview();
+    const visibleEntries = filterVisible(entries, isPreview);
 
     return (
         <div className={section.section}>
@@ -21,7 +25,7 @@ function Hub() {
                     <RichContent value={page.intro} />
                 </div>
                 <CategoryFilters categories={categories} />
-                <Grid entries={entries} />
+                <Grid entries={visibleEntries} />
             </div>
         </div>
     );

--- a/react-frontend/pages/hub/@slug/+data.ts
+++ b/react-frontend/pages/hub/@slug/+data.ts
@@ -1,4 +1,5 @@
 import type { PageContextServer } from 'vike/types';
+import { createElement } from 'react';
 import { render } from 'vike/abort';
 import { useConfig } from 'vike-react/useConfig';
 import { getHubEntryBySlug, getHubRecommendations } from '../../../src/APIs';
@@ -36,6 +37,17 @@ export async function data(pageContext: PageContextServer): Promise<HubEntryData
     config({
         title: `${entry.title} — Hub — Shawky Ebrahim`,
         description: entry.excerpt,
+        // Reference/dummy entries flagged hidden-in-production are still
+        // prerendered (so ?preview=1 can reach them), but must never be indexed
+        // by search engines. Bake a noindex robots meta into their <head>.
+        ...(entry.hiddenInProduction
+            ? {
+                  Head: createElement('meta', {
+                      name: 'robots',
+                      content: 'noindex,nofollow',
+                  }),
+              }
+            : {}),
     });
 
     // Recommendations come from the entry's primary (first resolvable)

--- a/react-frontend/pages/hub/category/@slug/+Page.tsx
+++ b/react-frontend/pages/hub/category/@slug/+Page.tsx
@@ -3,6 +3,8 @@ import ContainerWrap from '../../../../src/components/ContainerWrap';
 import Text from '../../../../src/components/Text';
 import CategoryFilters from '../../../../src/containers/Hub/CategoryFilters';
 import Grid from '../../../../src/containers/Hub/Grid';
+import { filterVisible } from '../../../../src/containers/Hub/visibility';
+import { useIsPreview } from '../../../../src/contexts/PreviewContext';
 import { cx } from '../../../../src/utils/cx';
 import type { HubCategoryData } from './+data';
 import section from '../../../../src/styles/section.module.css';
@@ -11,6 +13,8 @@ import lede from '../../../../src/styles/lede.module.css';
 
 function HubCategoryPage() {
     const { category, entries, categories } = useData<HubCategoryData>();
+    const isPreview = useIsPreview();
+    const visibleEntries = filterVisible(entries, isPreview);
 
     return (
         <div className={section.section}>
@@ -20,7 +24,7 @@ function HubCategoryPage() {
                     <Text variant="body" className={lede.lede}>{category.description}</Text>
                 )}
                 <CategoryFilters categories={categories} activeSlug={category.slug} />
-                <Grid entries={entries} />
+                <Grid entries={visibleEntries} />
             </div>
         </div>
     );

--- a/react-frontend/src/APIs/Sanity/hub.ts
+++ b/react-frontend/src/APIs/Sanity/hub.ts
@@ -19,6 +19,7 @@ const entrySummaryProjection = `{
     featured,
     featuredInCategory,
     "accentColor": accent.hex,
+    hiddenInProduction,
     "categories": categories[]->{ title, "slug": slug.current }
 }`;
 
@@ -59,6 +60,7 @@ const getHubEntryBySlug = async (slug: string) => {
         featured,
         featuredInCategory,
         "accentColor": accent.hex,
+        hiddenInProduction,
         channelHandle,
         platforms,
         tags,

--- a/react-frontend/src/Types/sanity/hubEntry.ts
+++ b/react-frontend/src/Types/sanity/hubEntry.ts
@@ -43,6 +43,11 @@ export type SanityHubEntrySummary = {
     // from it); otherwise the entry's kind default is used. Mirrors the Sanity
     // `accent` colour field, projected as `accent.hex`.
     accentColor?: string;
+    // When true, the entry is hidden from every production listing (Hub index,
+    // categories, About teaser, recommendations). Still shown in local dev and
+    // when preview mode is on (?preview=1). Mirrors the Sanity
+    // `hiddenInProduction` boolean; absent/false means publicly visible.
+    hiddenInProduction?: boolean;
     // Items can be `null` if a referenced hubCategory is deleted or
     // temporarily unresolvable — callers must filter before rendering.
     categories: (HubEntryCategoryRef | null)[];

--- a/react-frontend/src/components/HubCard/HubCard.module.css
+++ b/react-frontend/src/components/HubCard/HubCard.module.css
@@ -5,6 +5,27 @@
     color: inherit;
     transition: var(--transition);
     max-width: 380px;
+    position: relative;
+}
+
+.hiddenPill {
+    position: absolute;
+    top: 0.75rem;
+    left: 0.75rem;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--color-bg, #fff);
+    background: color-mix(in srgb, var(--color-text, #000) 78%, transparent);
+    backdrop-filter: blur(4px);
+    box-shadow: var(--shadow);
+    pointer-events: none;
 }
 
 .card:hover,

--- a/react-frontend/src/components/HubCard/index.tsx
+++ b/react-frontend/src/components/HubCard/index.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faNewspaper, faPodcast, faBookOpen, faTv } from '@fortawesome/free-solid-svg-icons';
+import { faNewspaper, faPodcast, faBookOpen, faTv, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { cx } from '../../utils/cx';
 import Text from '../Text';
 import ListButtons from '../ListButtons';
@@ -27,9 +27,13 @@ export type HubCardProps = {
     readonly categories: (HubEntryCategoryRef | null)[];
     readonly language?: HubContentLanguage;
     readonly accentColor?: string;
+    // Marks a card that is hidden from production listings — only ever visible
+    // in local dev or preview mode. Shows a small "Hidden" pill so you can tell
+    // reference/dummy entries apart at a glance.
+    readonly hidden?: boolean;
 };
 
-function HubCard({ title, slug, kind, excerpt, coverImage, sourceThumbnail, durationLabel, categories, language = 'en', accentColor }: HubCardProps) {
+function HubCard({ title, slug, kind, excerpt, coverImage, sourceThumbnail, durationLabel, categories, language = 'en', accentColor, hidden }: HubCardProps) {
     const { icon, label } = KIND_META[kind] ?? KIND_META.article;
     const image = coverImage ?? sourceThumbnail;
     const isRTL = language === 'ar';
@@ -37,6 +41,12 @@ function HubCard({ title, slug, kind, excerpt, coverImage, sourceThumbnail, dura
 
     return (
         <a href={`/hub/${slug}`} className={cx(surfaces.container, styles.card)} style={accentStyle(kind, accentColor)}>
+            {hidden && (
+                <span className={styles.hiddenPill} title="Hidden from production — visible only in preview mode">
+                    <FontAwesomeIcon icon={faEyeSlash} />
+                    Hidden
+                </span>
+            )}
             {image && (
                 <div className={styles.imageFrame}>
                     <img className={styles.image} src={image} alt="" loading="lazy" />

--- a/react-frontend/src/components/PreviewBanner/PreviewBanner.module.css
+++ b/react-frontend/src/components/PreviewBanner/PreviewBanner.module.css
@@ -1,0 +1,51 @@
+.banner {
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-bg, #fff);
+    background: color-mix(in srgb, var(--color-text, #000) 85%, transparent);
+    backdrop-filter: blur(8px);
+    box-shadow: var(--shadow);
+    max-width: calc(100vw - 2rem);
+}
+
+.label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.exit {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    padding: 0.35rem 0.8rem;
+    border: none;
+    border-radius: 999px;
+    font: inherit;
+    cursor: pointer;
+    color: var(--color-text, #000);
+    background: var(--color-bg, #fff);
+    transition: var(--transition);
+}
+
+.exit:hover,
+.exit:focus-visible {
+    opacity: 0.85;
+}
+
+@media (max-width: 480px) {
+    .banner {
+        font-size: 0.75rem;
+        gap: 0.5rem;
+    }
+}

--- a/react-frontend/src/components/PreviewBanner/index.tsx
+++ b/react-frontend/src/components/PreviewBanner/index.tsx
@@ -1,0 +1,26 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEye, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { usePreview } from '../../contexts/PreviewContext';
+import styles from './PreviewBanner.module.css';
+
+// Slim fixed banner shown ONLY when preview mode was explicitly enabled on the
+// live site (?preview=1). It never shows in local dev (where preview is always
+// on and a banner would just be noise). Lets you exit back to the normal
+// production view in one click.
+export default function PreviewBanner() {
+    const { isExplicit, exitPreview } = usePreview();
+    if (!isExplicit) return null;
+
+    return (
+        <div className={styles.banner} role="status">
+            <span className={styles.label}>
+                <FontAwesomeIcon icon={faEye} />
+                Preview mode — hidden entries are visible
+            </span>
+            <button type="button" className={styles.exit} onClick={exitPreview}>
+                <FontAwesomeIcon icon={faXmark} />
+                Exit
+            </button>
+        </div>
+    );
+}

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -4,6 +4,8 @@ import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
 import Text from '../../components/Text';
 import StarBorder from '../../components/StarBorder';
 import HubCard from '../../components/HubCard';
+import { filterVisible } from '../Hub/visibility';
+import { useIsPreview } from '../../contexts/PreviewContext';
 import buttonStyles from '../../components/Button/Button.module.css';
 import { cx } from '../../utils/cx';
 import type { SanityHubEntrySummary } from '../../Types';
@@ -19,11 +21,16 @@ type HubTeaserProps = {
 // curated yet. The responsive grid wraps to as many rows as needed, so there's
 // no fixed entry count.
 function HubTeaser({ entries }: HubTeaserProps) {
+    const isPreview = useIsPreview();
     // Entries come from dereferencing `featuredInAbout` refs; a stale/broken
     // reference (e.g. the target was deleted, or is temporarily unreadable)
     // resolves to `null` in the array rather than being dropped, so guard
-    // against that instead of crashing the whole page.
-    const resolvedEntries = entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry));
+    // against that instead of crashing the whole page. Hidden entries are also
+    // filtered unless preview mode is on.
+    const resolvedEntries = filterVisible(
+        entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
+        isPreview,
+    );
     if (resolvedEntries.length === 0) return null;
 
     return (
@@ -49,6 +56,7 @@ function HubTeaser({ entries }: HubTeaserProps) {
                         categories={entry.categories}
                         language={entry.language}
                         accentColor={entry.accentColor}
+                        hidden={entry.hiddenInProduction}
                     />
                 ))}
             </div>

--- a/react-frontend/src/containers/Hub/Grid.tsx
+++ b/react-frontend/src/containers/Hub/Grid.tsx
@@ -27,6 +27,7 @@ function Grid({ entries }: GridProps) {
                     categories={entry.categories}
                     language={entry.language}
                     accentColor={entry.accentColor}
+                    hidden={entry.hiddenInProduction}
                 />
             ))}
         </div>

--- a/react-frontend/src/containers/Hub/HubRecommendations.tsx
+++ b/react-frontend/src/containers/Hub/HubRecommendations.tsx
@@ -3,6 +3,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLayerGroup } from '@fortawesome/free-solid-svg-icons';
 import Text from '../../components/Text';
 import Grid from './Grid';
+import { filterVisible } from './visibility';
+import { useIsPreview } from '../../contexts/PreviewContext';
 import type { SanityHubEntrySummary } from '../../Types';
 import styles from './HubRecommendations.module.css';
 
@@ -11,7 +13,9 @@ type HubRecommendationsProps = {
 };
 
 function HubRecommendations({ entries }: HubRecommendationsProps) {
-    if (entries.length === 0) return null;
+    const isPreview = useIsPreview();
+    const visibleEntries = filterVisible(entries, isPreview);
+    if (visibleEntries.length === 0) return null;
 
     return (
         <section className={styles.section} aria-label="You might also like">
@@ -26,7 +30,7 @@ function HubRecommendations({ entries }: HubRecommendationsProps) {
                 </div>
                 <hr className={styles.divider} />
             </header>
-            <Grid entries={entries} />
+            <Grid entries={visibleEntries} />
         </section>
     );
 }

--- a/react-frontend/src/containers/Hub/visibility.ts
+++ b/react-frontend/src/containers/Hub/visibility.ts
@@ -1,0 +1,13 @@
+import type { SanityHubEntrySummary } from '../../Types';
+
+// Drops entries flagged `hiddenInProduction` unless preview mode is on. Used at
+// every listing surface (Hub index, category page, About teaser,
+// recommendations) so hidden reference/dummy entries stay out of the live site
+// but remain visible locally and via ?preview=1.
+export function filterVisible<T extends Pick<SanityHubEntrySummary, 'hiddenInProduction'>>(
+    entries: T[],
+    isPreview: boolean,
+): T[] {
+    if (isPreview) return entries;
+    return entries.filter((entry) => !entry.hiddenInProduction);
+}

--- a/react-frontend/src/contexts/PreviewContext.tsx
+++ b/react-frontend/src/contexts/PreviewContext.tsx
@@ -1,0 +1,90 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+// Client-side "preview mode" gate for hidden Hub entries.
+//
+// The site is a static prerender (no server), so entries flagged
+// `hiddenInProduction` are still shipped to production — they're just filtered
+// out of every listing on the client. Preview mode reveals them:
+//   - Local development (import.meta.env.DEV) is ALWAYS in preview mode.
+//   - On the live site, visiting any URL with ?preview=1 turns it on and
+//     persists it (localStorage); ?preview=0 turns it back off.
+//
+// This is an unlisted gate, not a security boundary: the hidden data is present
+// in the bundle. Hidden entry pages are additionally marked noindex.
+
+const STORAGE_KEY = 'hub:preview';
+
+type PreviewContextValue = {
+    isPreview: boolean;
+    // True only when preview was explicitly enabled on the live site (not the
+    // always-on local-dev case) — used to decide whether to show the banner.
+    isExplicit: boolean;
+    exitPreview: () => void;
+};
+
+const Context = createContext<PreviewContextValue>({
+    isPreview: false,
+    isExplicit: false,
+    exitPreview: () => {},
+});
+
+export const usePreview = () => useContext(Context);
+export const useIsPreview = () => useContext(Context).isPreview;
+
+type PreviewProviderProps = {
+    readonly children: ReactNode;
+};
+
+export default function PreviewProvider({ children }: PreviewProviderProps) {
+    // Initial value must be identical on the server (prerender) and the first
+    // client render to avoid a hydration mismatch. import.meta.env.DEV is a
+    // build-time constant, so it satisfies that. The real (localStorage/URL)
+    // value is resolved in the effect below, after hydration.
+    const [isPreview, setIsPreview] = useState<boolean>(import.meta.env.DEV);
+    const [isExplicit, setIsExplicit] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (import.meta.env.DEV) {
+            setIsPreview(true);
+            return;
+        }
+        let enabled: boolean;
+        try {
+            const param = new URLSearchParams(window.location.search).get('preview');
+            if (param === '1') {
+                localStorage.setItem(STORAGE_KEY, '1');
+                enabled = true;
+            } else if (param === '0') {
+                localStorage.removeItem(STORAGE_KEY);
+                enabled = false;
+            } else {
+                enabled = localStorage.getItem(STORAGE_KEY) === '1';
+            }
+        } catch {
+            enabled = false;
+        }
+        setIsPreview(enabled);
+        setIsExplicit(enabled);
+    }, []);
+
+    const exitPreview = useCallback(() => {
+        try {
+            localStorage.removeItem(STORAGE_KEY);
+        } catch {
+            /* ignore */
+        }
+        // Drop any ?preview param from the URL and reload so the prerendered
+        // (production-default) view is restored cleanly.
+        const url = new URL(window.location.href);
+        url.searchParams.delete('preview');
+        window.location.replace(url.toString());
+    }, []);
+
+    const value = useMemo(
+        () => ({ isPreview, isExplicit, exitPreview }),
+        [isPreview, isExplicit, exitPreview],
+    );
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+}

--- a/sanity-backend/schemas/hub/hubEntry.ts
+++ b/sanity-backend/schemas/hub/hubEntry.ts
@@ -247,6 +247,14 @@ export const hubEntry = {
                 'Highlights this entry as a pick on its detail page (shows an "Editor\'s pick" badge). Independent of the global Hub-index feature flag above.',
             initialValue: false,
         },
+        {
+            name: 'hiddenInProduction',
+            type: 'boolean',
+            title: 'Hide from production (preview-only)',
+            description:
+                'When ON, this entry is hidden from every listing on the live site (Hub index, categories, About teaser, recommendations). It stays fully visible in local development, and can be revealed on the live site by adding ?preview=1 to any URL. Use this to keep reference/dummy entries around without showing them to visitors.',
+            initialValue: false,
+        },
     ],
     orderings: [
         {
@@ -256,10 +264,10 @@ export const hubEntry = {
         },
     ],
     preview: {
-        select: { title: 'title', kind: 'kind', media: 'coverImage' },
-        prepare: ({ title, kind, media }) => ({
-            title,
-            subtitle: kind,
+        select: { title: 'title', kind: 'kind', media: 'coverImage', hidden: 'hiddenInProduction' },
+        prepare: ({ title, kind, media, hidden }) => ({
+            title: hidden ? `🔒 ${title}` : title,
+            subtitle: hidden ? `${kind} · hidden in production` : kind,
             media,
         }),
     },

--- a/sanity-backend/scripts/flag-dummy-hidden.mjs
+++ b/sanity-backend/scripts/flag-dummy-hidden.mjs
@@ -1,0 +1,29 @@
+import { getCliClient } from 'sanity/cli';
+
+// One-off: flag every seeded [DUMMY] Hub entry as hidden-in-production so they
+// stay in the dataset as reference material but drop out of the live site's
+// listings (still reachable locally and via ?preview=1).
+const client = getCliClient({ apiVersion: '2023-01-01' });
+
+const run = async () => {
+    const dummies = await client.fetch(
+        `*[_type=="hubEntry" && title match "[DUMMY]*"]{_id, title}`,
+    );
+    if (dummies.length === 0) {
+        console.log('No [DUMMY] entries found.');
+        return;
+    }
+    console.log(`Flagging ${dummies.length} dummy entries as hidden:`);
+    let tx = client.transaction();
+    for (const doc of dummies) {
+        console.log(`  - ${doc._id}  ${doc.title}`);
+        tx = tx.patch(doc._id, (p) => p.set({ hiddenInProduction: true }));
+    }
+    await tx.commit();
+    console.log('Done.');
+};
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/sanity-backend/scripts/repair-accent-shape.mjs
+++ b/sanity-backend/scripts/repair-accent-shape.mjs
@@ -1,0 +1,88 @@
+import { getCliClient } from 'sanity/cli';
+
+// Repair: some hubEntry.accent values were written by earlier scripts as a
+// partial color object ({_type:'color', hex}) with no hsl/hsv/rgb/alpha. The
+// @sanity/color-input widget reads those sub-objects to render its picker, so a
+// partial value makes the field throw and disappear in Studio. This rewrites
+// every stored accent into the full, widget-compatible shape (computed from the
+// hex) so the field renders and stays editable.
+const client = getCliClient({ apiVersion: '2023-01-01' });
+
+const hexToRgb = (hex) => {
+    const h = hex.replace('#', '');
+    return {
+        r: parseInt(h.slice(0, 2), 16),
+        g: parseInt(h.slice(2, 4), 16),
+        b: parseInt(h.slice(4, 6), 16),
+    };
+};
+
+const rgbToHslHsv = ({ r, g, b }) => {
+    const rn = r / 255;
+    const gn = g / 255;
+    const bn = b / 255;
+    const max = Math.max(rn, gn, bn);
+    const min = Math.min(rn, gn, bn);
+    const d = max - min;
+
+    let h = 0;
+    if (d !== 0) {
+        if (max === rn) h = ((gn - bn) / d) % 6;
+        else if (max === gn) h = (bn - rn) / d + 2;
+        else h = (rn - gn) / d + 4;
+        h *= 60;
+        if (h < 0) h += 360;
+    }
+
+    const l = (max + min) / 2;
+    const sHsl = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
+
+    const v = max;
+    const sHsv = max === 0 ? 0 : d / max;
+
+    return {
+        hsl: { h, s: sHsl, l },
+        hsv: { h, s: sHsv, v },
+    };
+};
+
+const buildColor = (hex) => {
+    const rgb = hexToRgb(hex);
+    const { hsl, hsv } = rgbToHslHsv(rgb);
+    return {
+        _type: 'color',
+        hex,
+        alpha: 1,
+        hsl: { _type: 'hslaColor', a: 1, h: hsl.h, s: hsl.s, l: hsl.l },
+        hsv: { _type: 'hsvaColor', a: 1, h: hsv.h, s: hsv.s, v: hsv.v },
+        rgb: { _type: 'rgbaColor', a: 1, r: rgb.r, g: rgb.g, b: rgb.b },
+    };
+};
+
+const run = async () => {
+    // Any entry whose accent is missing the sub-objects the widget needs.
+    const broken = await client.fetch(
+        `*[_type=="hubEntry" && defined(accent) && (!defined(accent.rgb) || !defined(accent.hsl) || !defined(accent.hsv) || !defined(accent.alpha))]{_id, title, "hex": accent.hex}`,
+    );
+    if (broken.length === 0) {
+        console.log('No partial accent values found — nothing to repair.');
+        return;
+    }
+    console.log(`Repairing ${broken.length} accent value(s):`);
+    let tx = client.transaction();
+    for (const doc of broken) {
+        if (!doc.hex) {
+            console.log(`  - SKIP ${doc._id} (no hex to rebuild from)`);
+            continue;
+        }
+        console.log(`  - ${doc._id}  ${doc.title}  ${doc.hex}`);
+        tx = tx.patch(doc._id, (p) => p.set({ accent: buildColor(doc.hex) }));
+    }
+    await tx.commit();
+    console.log('Done.');
+};
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Promotes the Vike prototype line to be the new `Development` baseline and adds the **Hub production-visibility** feature on top.

This squash-merges the full body of work that has been living on `spike/vike-prototype` + `feat/hub-visibility`:

- **Framework migration**: Astro → **Vike** (SSG) for per-route SEO and full static prerender to Vercel.
- **Content Hub**: end-to-end "Things Worth Sharing" hub — articles, channels, podcasts, reading lists — with per-kind theming, per-entry accent colors, inline YouTube/Channel cards, curated per-category recommendations, RTL/Arabic support, and article reading experience (TOC, progress ring).
- **Hub production visibility flag**: dummy/reference entries ship to production but are filtered out of rendered listings; revealable client-side via `?preview=1` (persisted), with a preview banner, a "Hidden" pill in the Studio-authored cards, and `noindex` on hidden detail pages.

## Visibility feature details

- `filterVisible(entries, isPreview)` applied at all Hub listing surfaces (hub index, category pages, recommendations, About teaser).
- `PreviewProvider` / `useIsPreview()` gate — DEV always on; on the live site toggled by `?preview=1/0` and remembered in `localStorage`.
- Hidden entries get `robots: noindex,nofollow` on their detail pages.

## Validation

- `tsc --noEmit` ✅
- eslint ✅ (only pre-existing react-refresh warnings)
- `npm run build` ✅
- vitest 39/39 ✅
- Verified E2E on a production build via `vike preview`: dummies hidden by default, revealed under `?preview=1`, persists on reload, noindex confirmed.
