### PR TITLE
Design option 02 - Hub teaser: Horizontal Rail + Marquee header

### DIFF
--- a/react-frontend/src/APIs/Sanity/about.ts
+++ b/react-frontend/src/APIs/Sanity/about.ts
@@ -12,6 +12,7 @@ const getAboutPage = async () => {
             "slug": slug.current,
             kind,
             excerpt,
+            language,
             "coverImage": coverImage.asset->url,
             sourceThumbnail,
             sourceName,
@@ -19,6 +20,8 @@ const getAboutPage = async () => {
             externalUrl,
             publishedAt,
             featured,
+            hiddenInProduction,
+            "accentColor": accent.hex,
             "categories": categories[]->{ title, "slug": slug.current }
         },
     }`;

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -1,17 +1,18 @@
 .teaser {
     composes: container column from '../../styles/surfaces.module.css';
     align-items: flex-start;
-    gap: 1rem;
+    gap: 1.25rem;
     padding: 2rem;
     width: 100%;
     margin-top: 2rem;
+    overflow: hidden;
 }
 
 .header {
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.75rem;
+    gap: 0.85rem;
     width: 100%;
 }
 
@@ -26,25 +27,139 @@
     color: var(--color-secondary-500);
 }
 
-.divider {
+/* Marquee ticker — a scrolling strip of the featured titles that replaces the
+   static divider with a bit of editorial motion. */
+.marquee {
+    position: relative;
     width: 100%;
-    height: 1px;
-    margin: 0;
-    border: none;
-    background-color: var(--color-base-200);
+    overflow: hidden;
+    padding: 0.5rem 0;
+    border-top: 1px solid var(--color-base-200);
+    border-bottom: 1px solid var(--color-base-200);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
 }
 
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+.marqueeTrack {
+    display: inline-flex;
+    align-items: center;
+    gap: 2.5rem;
+    white-space: nowrap;
+    will-change: transform;
+    animation: hub-marquee 32s linear infinite;
+}
+
+.marquee:hover .marqueeTrack {
+    animation-play-state: paused;
+}
+
+.marqueeItem {
+    display: inline-flex;
+    align-items: center;
+    gap: 2.5rem;
+    font-size: var(--font-size-sm);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-base-600);
+}
+
+.marqueeDot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--color-secondary-500);
+}
+
+@keyframes hub-marquee {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+}
+
+/* Horizontal rail — a scroll-snapping row of cards. */
+.railWrap {
+    position: relative;
+    width: 100%;
+}
+
+.rail {
+    display: flex;
     gap: 1.5rem;
     width: 100%;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding: 0.5rem 0.25rem 1rem;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-base-300) transparent;
 }
 
-.grid > * {
+.rail::-webkit-scrollbar {
+    height: 8px;
+}
+
+.rail::-webkit-scrollbar-thumb {
+    background-color: var(--color-base-300);
+    border-radius: 999px;
+}
+
+.railItem {
+    flex: 0 0 300px;
+    scroll-snap-align: start;
+    display: flex;
+}
+
+.railItem > * {
+    width: 100%;
     max-width: none;
+}
+
+.railEnd {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    padding: 0 1rem;
+    scroll-snap-align: end;
+}
+
+/* Edge fades hinting there's more to scroll. */
+.fadeLeft,
+.fadeRight {
+    position: absolute;
+    top: 0;
+    bottom: 1rem;
+    width: 3rem;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.fadeLeft {
+    left: 0;
+    background: linear-gradient(90deg, var(--color-base-50), transparent);
+}
+
+.fadeRight {
+    right: 0;
+    background: linear-gradient(270deg, var(--color-base-50), transparent);
 }
 
 .cta {
     text-decoration: none;
+    white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .marqueeTrack {
+        animation: none;
+        transform: translateX(0);
+    }
+}
+
+@media (max-width: 768px) {
+    .teaser {
+        padding: 1.5rem;
+    }
+
+    .railItem {
+        flex-basis: 82%;
+    }
 }

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -4,6 +4,8 @@
     gap: 1.25rem;
     padding: 2rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     margin-top: 2rem;
     overflow: hidden;
 }
@@ -14,6 +16,8 @@
     align-items: stretch;
     gap: 0.85rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .titleRow {
@@ -32,6 +36,8 @@
 .marquee {
     position: relative;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     overflow: hidden;
     padding: 0.5rem 0;
     border-top: 1px solid var(--color-base-200);
@@ -80,12 +86,16 @@
 .railWrap {
     position: relative;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .rail {
     display: flex;
     gap: 1.5rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     padding: 0.5rem 0.25rem 1rem;

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -15,23 +15,22 @@ type HubTeaserProps = {
     readonly entries: (SanityHubEntrySummary | null)[];
 };
 
-// Small "Things Worth Sharing" teaser on the About/home page — surfaces a
-// hand-curated list of Hub entries (via about.featuredInAbout, in author order)
-// with a CTA to the full /hub index. Renders nothing when no entries are
-// curated yet. The responsive grid wraps to as many rows as needed, so there's
-// no fixed entry count.
+// "Things Worth Sharing" teaser — DESIGN 02: Horizontal Rail + Marquee header.
+// A scrolling ticker headline sits above a horizontal, scroll-snapping rail of
+// cards you can flick through. Curated Hub entries come from about.featuredInAbout
+// (author order); hidden entries are filtered unless preview mode is on.
 function HubTeaser({ entries }: HubTeaserProps) {
     const isPreview = useIsPreview();
-    // Entries come from dereferencing `featuredInAbout` refs; a stale/broken
-    // reference (e.g. the target was deleted, or is temporarily unreadable)
-    // resolves to `null` in the array rather than being dropped, so guard
-    // against that instead of crashing the whole page. Hidden entries are also
-    // filtered unless preview mode is on.
     const resolvedEntries = filterVisible(
         entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
         isPreview,
     );
     if (resolvedEntries.length === 0) return null;
+
+    // Build a seamless marquee from the entry titles; duplicated so the track
+    // can loop without a visible seam.
+    const tickerItems = resolvedEntries.map((entry) => entry.title);
+    const marqueeItems = [...tickerItems, ...tickerItems];
 
     return (
         <div className={styles.teaser}>
@@ -40,35 +39,51 @@ function HubTeaser({ entries }: HubTeaserProps) {
                     <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
                     <Text variant="h3">Things Worth Sharing</Text>
                 </div>
-                <hr className={styles.divider} />
+                <div className={styles.marquee} aria-hidden="true">
+                    <div className={styles.marqueeTrack}>
+                        {marqueeItems.map((title, i) => (
+                            <span className={styles.marqueeItem} key={`${title}-${i}`}>
+                                <span className={styles.marqueeDot} />
+                                {title}
+                            </span>
+                        ))}
+                    </div>
+                </div>
             </header>
-            <div className={styles.grid}>
-                {resolvedEntries.map((entry) => (
-                    <HubCard
-                        key={entry.slug}
-                        title={entry.title}
-                        slug={entry.slug}
-                        kind={entry.kind}
-                        excerpt={entry.excerpt}
-                        coverImage={entry.coverImage}
-                        sourceThumbnail={entry.sourceThumbnail}
-                        durationLabel={entry.durationLabel}
-                        categories={entry.categories}
-                        language={entry.language}
-                        accentColor={entry.accentColor}
-                        hidden={entry.hiddenInProduction}
-                    />
-                ))}
+
+            <div className={styles.railWrap}>
+                <div className={styles.rail}>
+                    {resolvedEntries.map((entry) => (
+                        <div className={styles.railItem} key={entry.slug}>
+                            <HubCard
+                                title={entry.title}
+                                slug={entry.slug}
+                                kind={entry.kind}
+                                excerpt={entry.excerpt}
+                                coverImage={entry.coverImage}
+                                sourceThumbnail={entry.sourceThumbnail}
+                                durationLabel={entry.durationLabel}
+                                categories={entry.categories}
+                                language={entry.language}
+                                accentColor={entry.accentColor}
+                                hidden={entry.hiddenInProduction}
+                            />
+                        </div>
+                    ))}
+                    <div className={styles.railEnd}>
+                        <StarBorder>
+                            <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
+                                Visit the Hub
+                                <FontAwesomeIcon icon={faArrowRight} />
+                            </a>
+                        </StarBorder>
+                    </div>
+                </div>
+                <span className={styles.fadeLeft} aria-hidden="true" />
+                <span className={styles.fadeRight} aria-hidden="true" />
             </div>
-            <StarBorder>
-                <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
-                    Visit the Hub
-                    <FontAwesomeIcon icon={faArrowRight} />
-                </a>
-            </StarBorder>
         </div>
     );
 }
 
 export default memo(HubTeaser);
-

--- a/sanity-backend/scripts/set-featured-demo.mjs
+++ b/sanity-backend/scripts/set-featured-demo.mjs
@@ -1,0 +1,44 @@
+import { getCliClient } from 'sanity/cli';
+
+// One-off: widen the About "Things Worth Sharing" featured list to a richer,
+// more varied set so the redesigned Hub teaser has enough content to show.
+// The 3 originals are kept; the 5 added entries are all hidden [DUMMY] docs, so
+// the LIVE production site is unchanged (they stay filtered out) while dev and
+// ?preview=1 render the full set for design evaluation.
+const client = getCliClient({ apiVersion: '2023-01-01' });
+
+const PORTFOLIO_ID = '38ff5cc9-0723-4e11-8279-0f7fbb323a33';
+const ABOUT_PAGE_KEY = '616f5fe510c1';
+
+// Order matters — this is the render order in the teaser.
+const REFS = [
+    'hubEntry-dummy-article-clean-architecture', // article, EN (hidden)
+    'hubEntry-channel-mataa3',                   // channel, AR + thumbnail (live)
+    'hubEntry-reading-developer-mindset',        // reading list, EN (live)
+    'hubEntry-dummy-book-atomic-habits',         // book, EN + cover (hidden)
+    'hubEntry-dummy-podcast-craft',              // podcast, EN (hidden)
+    'hubEntry-dummy-read-design-details',        // read, EN (hidden)
+    'hubEntry-dummy-article-shortcuts',          // article, EN (hidden)
+    'hubEntry-dummy-article-arabic-software',    // article, AR/RTL (hidden)
+];
+
+const run = async () => {
+    const featured = REFS.map((ref, i) => ({
+        _key: `feat${i}`,
+        _type: 'reference',
+        _ref: ref,
+    }));
+
+    await client
+        .patch(PORTFOLIO_ID)
+        .set({ [`pages[_key=="${ABOUT_PAGE_KEY}"].featuredInAbout`]: featured })
+        .commit();
+
+    console.log(`Set ${featured.length} featured Hub entries on the About page.`);
+    REFS.forEach((r) => console.log(`  - ${r}`));
+};
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
One of three Hub-teaser redesign options for comparison (pick one, others get closed). **Design 02:** a scrolling marquee ticker of the featured titles above a horizontal, scroll-snapping rail of cards with edge fades and a trailing 'Visit the Hub' CTA. Marquee pauses on hover and respects reduced-motion. Also fixes the About Sanity projection to fetch accentColor/language/hiddenInProduction so per-entry accents, Arabic RTL, and hidden filtering work in the teaser.