### PR TITLE
Design option 06 - Hub teaser: Collage / Pinboard

### DIFF
--- a/react-frontend/src/APIs/Sanity/about.ts
+++ b/react-frontend/src/APIs/Sanity/about.ts
@@ -12,6 +12,7 @@ const getAboutPage = async () => {
             "slug": slug.current,
             kind,
             excerpt,
+            language,
             "coverImage": coverImage.asset->url,
             sourceThumbnail,
             sourceName,
@@ -19,6 +20,8 @@ const getAboutPage = async () => {
             externalUrl,
             publishedAt,
             featured,
+            hiddenInProduction,
+            "accentColor": accent.hex,
             "categories": categories[]->{ title, "slug": slug.current }
         },
     }`;

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -1,10 +1,14 @@
 .teaser {
     composes: container column from '../../styles/surfaces.module.css';
     align-items: flex-start;
-    gap: 1rem;
+    gap: 1.5rem;
     padding: 2rem;
     width: 100%;
     margin-top: 2rem;
+    /* Faint pinboard texture layered over the section surface. */
+    background-image:
+        radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--color-base-400) 22%, transparent) 1px, transparent 0);
+    background-size: 22px 22px;
 }
 
 .header {
@@ -34,17 +38,87 @@
     background-color: var(--color-base-200);
 }
 
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 1.5rem;
+/* The board — a masonry-style scatter so cards of different heights nest like
+   pinned notes. */
+.board {
+    width: 100%;
+    column-gap: 2rem;
+    columns: 3 240px;
+    padding: 0.5rem 0.25rem;
+}
+
+.pin {
+    position: relative;
+    break-inside: avoid;
+    margin: 0 0 2rem;
+    transform: rotate(var(--rot, 0deg));
+    transition: transform 0.25s ease, filter 0.25s ease;
+    filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.16));
+}
+
+.pin:hover,
+.pin:focus-within {
+    transform: rotate(0deg) translateY(-4px) scale(1.02);
+    filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.22));
+    z-index: 2;
+}
+
+.pin > a {
+    max-width: none;
     width: 100%;
 }
 
-.grid > * {
-    max-width: none;
+/* A translucent strip of "tape" holding the card to the board. */
+.tape {
+    position: absolute;
+    top: -0.7rem;
+    left: 50%;
+    transform: translateX(-50%) rotate(calc(var(--rot, 0deg) * -1.4));
+    width: 5rem;
+    height: 1.4rem;
+    z-index: 3;
+    background: color-mix(in srgb, var(--color-base-100) 62%, transparent);
+    border-left: 1px solid rgba(255, 255, 255, 0.5);
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    pointer-events: none;
+}
+
+/* Accent-tinted tack pin, using the card's own --entry-accent when set. */
+.tack {
+    position: absolute;
+    top: -0.55rem;
+    left: 1.1rem;
+    z-index: 3;
+    font-size: 0.9rem;
+    color: var(--color-secondary-600);
+    transform: rotate(calc(var(--rot, 0deg) * -2));
+    filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.25));
+    pointer-events: none;
 }
 
 .cta {
     text-decoration: none;
+    align-self: flex-start;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pin {
+        transition: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .teaser {
+        padding: 1.5rem;
+    }
+
+    .board {
+        columns: 1;
+        column-gap: 0;
+    }
+
+    .pin {
+        transform: rotate(0deg);
+    }
 }

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
+import type { CSSProperties } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
+import { faArrowRight, faBookOpen, faThumbtack } from '@fortawesome/free-solid-svg-icons';
 import Text from '../../components/Text';
 import StarBorder from '../../components/StarBorder';
 import HubCard from '../../components/HubCard';
@@ -15,18 +16,16 @@ type HubTeaserProps = {
     readonly entries: (SanityHubEntrySummary | null)[];
 };
 
-// Small "Things Worth Sharing" teaser on the About/home page — surfaces a
-// hand-curated list of Hub entries (via about.featuredInAbout, in author order)
-// with a CTA to the full /hub index. Renders nothing when no entries are
-// curated yet. The responsive grid wraps to as many rows as needed, so there's
-// no fixed entry count.
+// Deterministic per-position tilt so the board looks hand-pinned but renders the
+// same every time (no layout jitter between server + client).
+const ROTATIONS = [-2.5, 1.8, -1.4, 2.3, -2, 1.3, -1.7, 2.6, -1.1, 2];
+
+// "Things Worth Sharing" teaser — DESIGN 06: Collage / Pinboard.
+// The featured entries are pinned to a board as slightly-rotated cards with a
+// strip of tape; hovering straightens and lifts a card. Curated Hub entries come
+// from about.featuredInAbout; hidden entries are filtered unless preview is on.
 function HubTeaser({ entries }: HubTeaserProps) {
     const isPreview = useIsPreview();
-    // Entries come from dereferencing `featuredInAbout` refs; a stale/broken
-    // reference (e.g. the target was deleted, or is temporarily unreadable)
-    // resolves to `null` in the array rather than being dropped, so guard
-    // against that instead of crashing the whole page. Hidden entries are also
-    // filtered unless preview mode is on.
     const resolvedEntries = filterVisible(
         entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
         isPreview,
@@ -42,24 +41,33 @@ function HubTeaser({ entries }: HubTeaserProps) {
                 </div>
                 <hr className={styles.divider} />
             </header>
-            <div className={styles.grid}>
-                {resolvedEntries.map((entry) => (
-                    <HubCard
+
+            <div className={styles.board}>
+                {resolvedEntries.map((entry, i) => (
+                    <div
+                        className={styles.pin}
                         key={entry.slug}
-                        title={entry.title}
-                        slug={entry.slug}
-                        kind={entry.kind}
-                        excerpt={entry.excerpt}
-                        coverImage={entry.coverImage}
-                        sourceThumbnail={entry.sourceThumbnail}
-                        durationLabel={entry.durationLabel}
-                        categories={entry.categories}
-                        language={entry.language}
-                        accentColor={entry.accentColor}
-                        hidden={entry.hiddenInProduction}
-                    />
+                        style={{ '--rot': `${ROTATIONS[i % ROTATIONS.length]}deg` } as CSSProperties}
+                    >
+                        <span className={styles.tape} aria-hidden="true" />
+                        <FontAwesomeIcon icon={faThumbtack} className={styles.tack} aria-hidden="true" />
+                        <HubCard
+                            title={entry.title}
+                            slug={entry.slug}
+                            kind={entry.kind}
+                            excerpt={entry.excerpt}
+                            coverImage={entry.coverImage}
+                            sourceThumbnail={entry.sourceThumbnail}
+                            durationLabel={entry.durationLabel}
+                            categories={entry.categories}
+                            language={entry.language}
+                            accentColor={entry.accentColor}
+                            hidden={entry.hiddenInProduction}
+                        />
+                    </div>
                 ))}
             </div>
+
             <StarBorder>
                 <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
                     Visit the Hub
@@ -71,4 +79,3 @@ function HubTeaser({ entries }: HubTeaserProps) {
 }
 
 export default memo(HubTeaser);
-


### PR DESCRIPTION
One of three Hub-teaser redesign options for comparison (pick one, others get closed). **Design 06:** featured entries are pinned to a masonry board as slightly-rotated cards, each with a strip of tape and a tack; hovering straightens and lifts the card. Faint dot-grid board texture. Collapses to a single upright column on mobile and respects reduced-motion. Includes the About projection fix (accentColor/language/hiddenInProduction).