### PR TITLE
Design option 07 - Hub teaser: Magazine Bento + Accent Spotlight

### DIFF
--- a/react-frontend/src/APIs/Sanity/about.ts
+++ b/react-frontend/src/APIs/Sanity/about.ts
@@ -12,6 +12,7 @@ const getAboutPage = async () => {
             "slug": slug.current,
             kind,
             excerpt,
+            language,
             "coverImage": coverImage.asset->url,
             sourceThumbnail,
             sourceName,
@@ -19,6 +20,8 @@ const getAboutPage = async () => {
             externalUrl,
             publishedAt,
             featured,
+            hiddenInProduction,
+            "accentColor": accent.hex,
             "categories": categories[]->{ title, "slug": slug.current }
         },
     }`;

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -1,10 +1,47 @@
 .teaser {
     composes: container column from '../../styles/surfaces.module.css';
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     align-items: flex-start;
-    gap: 1rem;
+    gap: 1.5rem;
     padding: 2rem;
     width: 100%;
     margin-top: 2rem;
+    transition: box-shadow 0.4s ease, border-color 0.4s ease;
+}
+
+/* When a card is spotlighted, echo its accent in the section frame. */
+.lit {
+    border-color: color-mix(in srgb, var(--spotlight) 40%, var(--color-base-200)) !important;
+    box-shadow:
+        var(--shadow),
+        0 0 0 1px color-mix(in srgb, var(--spotlight) 30%, transparent),
+        0 18px 50px -20px color-mix(in srgb, var(--spotlight) 55%, transparent);
+}
+
+/* Ambient wash behind the content — fades in on the hovered accent. */
+.ambient {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.45s ease, background 0.45s ease;
+    background:
+        radial-gradient(120% 80% at 50% -10%, color-mix(in srgb, var(--spotlight) 26%, transparent), transparent 68%),
+        radial-gradient(80% 60% at 90% 110%, color-mix(in srgb, var(--spotlight) 16%, transparent), transparent 60%);
+}
+
+.lit .ambient {
+    opacity: 1;
+}
+
+.header,
+.bento,
+.cta {
+    position: relative;
+    z-index: 1;
 }
 
 .header {
@@ -34,17 +71,79 @@
     background-color: var(--color-base-200);
 }
 
-.grid {
+/* Bento grid: one large hero cell + smaller satellites. */
+.bento {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(170px, auto);
+    grid-auto-flow: row dense;
     gap: 1.5rem;
     width: 100%;
 }
 
-.grid > * {
+.cell {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    grid-column: span 2;
+    transition: opacity 0.35s ease, filter 0.35s ease, transform 0.35s ease;
+}
+
+.cell > * {
+    width: 100%;
     max-width: none;
+}
+
+.hero {
+    grid-column: span 2;
+    grid-row: span 2;
+}
+
+/* Non-spotlighted cards recede while another is hovered. */
+.dimmed {
+    opacity: 0.42;
+    filter: saturate(0.55);
+    transform: scale(0.99);
 }
 
 .cta {
     text-decoration: none;
+    align-self: flex-start;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .teaser,
+    .ambient,
+    .cell {
+        transition: none;
+    }
+}
+
+@media (max-width: 900px) {
+    .bento {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .cell,
+    .hero {
+        grid-column: span 1;
+        grid-row: auto;
+    }
+}
+
+@media (max-width: 560px) {
+    .teaser {
+        padding: 1.5rem;
+    }
+
+    .bento {
+        grid-template-columns: 1fr;
+    }
+
+    /* Touch has no hover — never leave cards dimmed. */
+    .dimmed {
+        opacity: 1;
+        filter: none;
+        transform: none;
+    }
 }

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -1,10 +1,12 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
 import Text from '../../components/Text';
 import StarBorder from '../../components/StarBorder';
 import HubCard from '../../components/HubCard';
 import { filterVisible } from '../Hub/visibility';
+import { KIND_ACCENT } from '../Hub/kindAccent';
 import { useIsPreview } from '../../contexts/PreviewContext';
 import buttonStyles from '../../components/Button/Button.module.css';
 import { cx } from '../../utils/cx';
@@ -15,26 +17,74 @@ type HubTeaserProps = {
     readonly entries: (SanityHubEntrySummary | null)[];
 };
 
-// Small "Things Worth Sharing" teaser on the About/home page — surfaces a
-// hand-curated list of Hub entries (via about.featuredInAbout, in author order)
-// with a CTA to the full /hub index. Renders nothing when no entries are
-// curated yet. The responsive grid wraps to as many rows as needed, so there's
-// no fixed entry count.
+// The colour that drives both the card accent and the ambient spotlight for an
+// entry — a per-entry accent wins, otherwise the kind default.
+function entryAccent(entry: SanityHubEntrySummary): string {
+    return entry.accentColor ?? KIND_ACCENT[entry.kind] ?? KIND_ACCENT.article;
+}
+
+// "Things Worth Sharing" teaser — DESIGN 07: Magazine Bento + Accent Spotlight.
+// A bento grid with one large hero cell + smaller satellites. Hovering (or
+// focusing) any card washes the whole section in that entry's accent and dims
+// the others, so attention follows the pointer. Curated Hub entries come from
+// about.featuredInAbout; hidden entries are filtered unless preview is on.
 function HubTeaser({ entries }: HubTeaserProps) {
     const isPreview = useIsPreview();
-    // Entries come from dereferencing `featuredInAbout` refs; a stale/broken
-    // reference (e.g. the target was deleted, or is temporarily unreadable)
-    // resolves to `null` in the array rather than being dropped, so guard
-    // against that instead of crashing the whole page. Hidden entries are also
-    // filtered unless preview mode is on.
     const resolvedEntries = filterVisible(
         entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
         isPreview,
     );
+
+    // Which entry is currently spotlighted (by slug) + its accent colour.
+    const [active, setActive] = useState<{ slug: string; accent: string } | null>(null);
+
     if (resolvedEntries.length === 0) return null;
 
+    // Hero = the first entry that carries an image (biggest visual payoff in the
+    // large cell); fall back to the first entry. The rest keep author order.
+    const heroIndex = Math.max(
+        0,
+        resolvedEntries.findIndex((e) => Boolean(e.coverImage ?? e.sourceThumbnail)),
+    );
+    const hero = resolvedEntries[heroIndex];
+    const rest = resolvedEntries.filter((_, i) => i !== heroIndex);
+    const ordered = [hero, ...rest];
+
+    const renderCard = (entry: SanityHubEntrySummary, isHero: boolean) => {
+        const accent = entryAccent(entry);
+        const dimmed = active !== null && active.slug !== entry.slug;
+        return (
+            <div
+                key={entry.slug}
+                className={cx(styles.cell, isHero && styles.hero, dimmed && styles.dimmed)}
+                onMouseEnter={() => setActive({ slug: entry.slug, accent })}
+                onFocusCapture={() => setActive({ slug: entry.slug, accent })}
+            >
+                <HubCard
+                    title={entry.title}
+                    slug={entry.slug}
+                    kind={entry.kind}
+                    excerpt={entry.excerpt}
+                    coverImage={entry.coverImage}
+                    sourceThumbnail={entry.sourceThumbnail}
+                    durationLabel={entry.durationLabel}
+                    categories={entry.categories}
+                    language={entry.language}
+                    accentColor={entry.accentColor}
+                    hidden={entry.hiddenInProduction}
+                />
+            </div>
+        );
+    };
+
     return (
-        <div className={styles.teaser}>
+        <div
+            className={cx(styles.teaser, active && styles.lit)}
+            style={{ '--spotlight': active?.accent ?? 'transparent' } as CSSProperties}
+            onMouseLeave={() => setActive(null)}
+            onBlurCapture={() => setActive(null)}
+        >
+            <span className={styles.ambient} aria-hidden="true" />
             <header className={styles.header}>
                 <div className={styles.titleRow}>
                     <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
@@ -42,24 +92,11 @@ function HubTeaser({ entries }: HubTeaserProps) {
                 </div>
                 <hr className={styles.divider} />
             </header>
-            <div className={styles.grid}>
-                {resolvedEntries.map((entry) => (
-                    <HubCard
-                        key={entry.slug}
-                        title={entry.title}
-                        slug={entry.slug}
-                        kind={entry.kind}
-                        excerpt={entry.excerpt}
-                        coverImage={entry.coverImage}
-                        sourceThumbnail={entry.sourceThumbnail}
-                        durationLabel={entry.durationLabel}
-                        categories={entry.categories}
-                        language={entry.language}
-                        accentColor={entry.accentColor}
-                        hidden={entry.hiddenInProduction}
-                    />
-                ))}
+
+            <div className={styles.bento}>
+                {ordered.map((entry, i) => renderCard(entry, i === 0))}
             </div>
+
             <StarBorder>
                 <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
                     Visit the Hub
@@ -71,4 +108,3 @@ function HubTeaser({ entries }: HubTeaserProps) {
 }
 
 export default memo(HubTeaser);
-


### PR DESCRIPTION
One of three Hub-teaser redesign options for comparison (pick one, others get closed). **Design 07 (combo):** a bento grid with one large hero cell (first entry with an image) plus smaller satellites; hovering or focusing any card washes the whole section in that entry's accent colour and dims the others so attention follows the pointer. Accent resolves per-entry (custom Sanity accent, else kind default). Reduced-motion and touch (no dimming) handled. Includes the About projection fix (accentColor/language/hiddenInProduction).