### PR TITLE
Design showcase - all three Hub teaser designs stacked for comparison

### DIFF
--- a/react-frontend/src/APIs/Sanity/about.ts
+++ b/react-frontend/src/APIs/Sanity/about.ts
@@ -12,6 +12,7 @@ const getAboutPage = async () => {
             "slug": slug.current,
             kind,
             excerpt,
+            language,
             "coverImage": coverImage.asset->url,
             sourceThumbnail,
             sourceName,
@@ -19,6 +20,8 @@ const getAboutPage = async () => {
             externalUrl,
             publishedAt,
             featured,
+            hiddenInProduction,
+            "accentColor": accent.hex,
             "categories": categories[]->{ title, "slug": slug.current }
         },
     }`;

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -3,6 +3,8 @@
     flex-direction: column;
     gap: 2.5rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .slot {
@@ -10,6 +12,8 @@
     flex-direction: column;
     gap: 0.5rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
 }
 
 /* Label banner marking each candidate design in the comparison scaffold. */

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -1,50 +1,63 @@
-.teaser {
-    composes: container column from '../../styles/surfaces.module.css';
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 2rem;
-    width: 100%;
-    margin-top: 2rem;
-}
-
-.header {
+.showcase {
     display: flex;
     flex-direction: column;
-    align-items: stretch;
-    gap: 0.75rem;
+    gap: 2.5rem;
     width: 100%;
 }
 
-.titleRow {
+.slot {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+}
+
+/* Label banner marking each candidate design in the comparison scaffold. */
+.banner {
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    color: var(--color-base-700);
+    padding: 0.6rem 0.9rem;
+    border-radius: var(--radius);
+    background: color-mix(in srgb, var(--color-secondary-500) 8%, var(--color-base-0));
+    border: 1px dashed color-mix(in srgb, var(--color-secondary-500) 40%, transparent);
 }
 
-.titleIcon {
-    color: var(--color-secondary-500);
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    font-size: var(--font-size-sm);
+    font-weight: 700;
+    color: var(--color-base-0);
+    background-color: var(--color-secondary-600);
 }
 
-.divider {
-    width: 100%;
-    height: 1px;
-    margin: 0;
-    border: none;
-    background-color: var(--color-base-200);
+.bannerText {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
 }
 
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 1.5rem;
-    width: 100%;
+.label {
+    font-weight: 600;
+    color: var(--color-base-800);
+    font-size: var(--font-size-sm);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
 }
 
-.grid > * {
-    max-width: none;
+.blurb {
+    font-size: var(--font-size-sm);
+    color: var(--color-base-600);
 }
 
-.cta {
-    text-decoration: none;
+/* The showcase already spaces slots; drop the per-teaser top margin. */
+.slot > div {
+    margin-top: 0 !important;
 }

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -1,13 +1,7 @@
 import { memo } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
-import Text from '../../components/Text';
-import StarBorder from '../../components/StarBorder';
-import HubCard from '../../components/HubCard';
-import { filterVisible } from '../Hub/visibility';
-import { useIsPreview } from '../../contexts/PreviewContext';
-import buttonStyles from '../../components/Button/Button.module.css';
-import { cx } from '../../utils/cx';
+import RailTeaser from './variants/RailTeaser';
+import PinboardTeaser from './variants/PinboardTeaser';
+import BentoSpotlightTeaser from './variants/BentoSpotlightTeaser';
 import type { SanityHubEntrySummary } from '../../Types';
 import styles from './HubTeaser.module.css';
 
@@ -15,60 +9,53 @@ type HubTeaserProps = {
     readonly entries: (SanityHubEntrySummary | null)[];
 };
 
-// Small "Things Worth Sharing" teaser on the About/home page — surfaces a
-// hand-curated list of Hub entries (via about.featuredInAbout, in author order)
-// with a CTA to the full /hub index. Renders nothing when no entries are
-// curated yet. The responsive grid wraps to as many rows as needed, so there's
-// no fixed entry count.
-function HubTeaser({ entries }: HubTeaserProps) {
-    const isPreview = useIsPreview();
-    // Entries come from dereferencing `featuredInAbout` refs; a stale/broken
-    // reference (e.g. the target was deleted, or is temporarily unreadable)
-    // resolves to `null` in the array rather than being dropped, so guard
-    // against that instead of crashing the whole page. Hidden entries are also
-    // filtered unless preview mode is on.
-    const resolvedEntries = filterVisible(
-        entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
-        isPreview,
-    );
-    if (resolvedEntries.length === 0) return null;
+// SHOWCASE build: renders the "Things Worth Sharing" section three times, once
+// per candidate design, each behind a labeled banner — so the three directions
+// can be compared on one page without switching branches. Pick a winner, then
+// this wrapper is replaced by the single chosen variant.
+const VARIANTS: readonly {
+    id: string;
+    label: string;
+    blurb: string;
+    Component: typeof RailTeaser;
+}[] = [
+    {
+        id: '02',
+        label: 'Design 02 · Horizontal Rail + Marquee',
+        blurb: 'Scrolling ticker headline over a flick-through, scroll-snapping rail of cards.',
+        Component: RailTeaser,
+    },
+    {
+        id: '06',
+        label: 'Design 06 · Collage / Pinboard',
+        blurb: 'Cards pinned to a masonry board with tape + tack; hover straightens and lifts.',
+        Component: PinboardTeaser,
+    },
+    {
+        id: '07',
+        label: 'Design 07 · Magazine Bento + Accent Spotlight',
+        blurb: 'Bento grid with a hero cell; hovering a card washes the section in its accent.',
+        Component: BentoSpotlightTeaser,
+    },
+];
 
+function HubTeaser({ entries }: HubTeaserProps) {
     return (
-        <div className={styles.teaser}>
-            <header className={styles.header}>
-                <div className={styles.titleRow}>
-                    <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
-                    <Text variant="h3">Things Worth Sharing</Text>
-                </div>
-                <hr className={styles.divider} />
-            </header>
-            <div className={styles.grid}>
-                {resolvedEntries.map((entry) => (
-                    <HubCard
-                        key={entry.slug}
-                        title={entry.title}
-                        slug={entry.slug}
-                        kind={entry.kind}
-                        excerpt={entry.excerpt}
-                        coverImage={entry.coverImage}
-                        sourceThumbnail={entry.sourceThumbnail}
-                        durationLabel={entry.durationLabel}
-                        categories={entry.categories}
-                        language={entry.language}
-                        accentColor={entry.accentColor}
-                        hidden={entry.hiddenInProduction}
-                    />
-                ))}
-            </div>
-            <StarBorder>
-                <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
-                    Visit the Hub
-                    <FontAwesomeIcon icon={faArrowRight} />
-                </a>
-            </StarBorder>
+        <div className={styles.showcase}>
+            {VARIANTS.map(({ id, label, blurb, Component }) => (
+                <section className={styles.slot} key={id} aria-label={label}>
+                    <div className={styles.banner}>
+                        <span className={styles.badge}>{id}</span>
+                        <div className={styles.bannerText}>
+                            <span className={styles.label}>{label}</span>
+                            <span className={styles.blurb}>{blurb}</span>
+                        </div>
+                    </div>
+                    <Component entries={entries} />
+                </section>
+            ))}
         </div>
     );
 }
 
 export default memo(HubTeaser);
-

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import MagazineBentoTeaser from './variants/MagazineBentoTeaser';
 import RailTeaser from './variants/RailTeaser';
 import PinboardTeaser from './variants/PinboardTeaser';
 import BentoSpotlightTeaser from './variants/BentoSpotlightTeaser';
@@ -19,6 +20,12 @@ const VARIANTS: readonly {
     blurb: string;
     Component: typeof RailTeaser;
 }[] = [
+    {
+        id: '01',
+        label: 'Design 01 · Magazine Bento',
+        blurb: 'Asymmetric bento on a dark editorial canvas: one large featured pick + satellite cards, index numerals, accent rails.',
+        Component: MagazineBentoTeaser,
+    },
     {
         id: '02',
         label: 'Design 02 · Horizontal Rail + Marquee',

--- a/react-frontend/src/containers/About/variants/BentoSpotlightTeaser.module.css
+++ b/react-frontend/src/containers/About/variants/BentoSpotlightTeaser.module.css
@@ -1,0 +1,150 @@
+﻿.teaser {
+    composes: container column from '../../../styles/surfaces.module.css';
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 2rem;
+    width: 100%;
+    margin-top: 2rem;
+    transition: box-shadow 0.4s ease, border-color 0.4s ease;
+}
+
+/* When a card is spotlighted, echo its accent in the section frame. */
+.lit {
+    border-color: color-mix(in srgb, var(--spotlight) 40%, var(--color-base-200)) !important;
+    box-shadow:
+        var(--shadow),
+        0 0 0 1px color-mix(in srgb, var(--spotlight) 30%, transparent),
+        0 18px 50px -20px color-mix(in srgb, var(--spotlight) 55%, transparent);
+}
+
+/* Ambient wash behind the content — fades in on the hovered accent. */
+.ambient {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.45s ease, background 0.45s ease;
+    background:
+        radial-gradient(120% 80% at 50% -10%, color-mix(in srgb, var(--spotlight) 26%, transparent), transparent 68%),
+        radial-gradient(80% 60% at 90% 110%, color-mix(in srgb, var(--spotlight) 16%, transparent), transparent 60%);
+}
+
+.lit .ambient {
+    opacity: 1;
+}
+
+.header,
+.bento,
+.cta {
+    position: relative;
+    z-index: 1;
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    width: 100%;
+}
+
+.titleRow {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--color-base-700);
+}
+
+.titleIcon {
+    color: var(--color-secondary-500);
+}
+
+.divider {
+    width: 100%;
+    height: 1px;
+    margin: 0;
+    border: none;
+    background-color: var(--color-base-200);
+}
+
+/* Bento grid: one large hero cell + smaller satellites. */
+.bento {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(170px, auto);
+    grid-auto-flow: row dense;
+    gap: 1.5rem;
+    width: 100%;
+}
+
+.cell {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    grid-column: span 2;
+    transition: opacity 0.35s ease, filter 0.35s ease, transform 0.35s ease;
+}
+
+.cell > * {
+    width: 100%;
+    max-width: none;
+}
+
+.hero {
+    grid-column: span 2;
+    grid-row: span 2;
+}
+
+/* Non-spotlighted cards recede while another is hovered. */
+.dimmed {
+    opacity: 0.42;
+    filter: saturate(0.55);
+    transform: scale(0.99);
+}
+
+.cta {
+    text-decoration: none;
+    align-self: flex-start;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .teaser,
+    .ambient,
+    .cell {
+        transition: none;
+    }
+}
+
+@media (max-width: 900px) {
+    .bento {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .cell,
+    .hero {
+        grid-column: span 1;
+        grid-row: auto;
+    }
+}
+
+@media (max-width: 560px) {
+    .teaser {
+        padding: 1.5rem;
+    }
+
+    .bento {
+        grid-template-columns: 1fr;
+    }
+
+    /* Touch has no hover — never leave cards dimmed. */
+    .dimmed {
+        opacity: 1;
+        filter: none;
+        transform: none;
+    }
+}
+

--- a/react-frontend/src/containers/About/variants/BentoSpotlightTeaser.tsx
+++ b/react-frontend/src/containers/About/variants/BentoSpotlightTeaser.tsx
@@ -1,0 +1,105 @@
+import { memo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
+import Text from '../../../components/Text';
+import StarBorder from '../../../components/StarBorder';
+import HubCard from '../../../components/HubCard';
+import { filterVisible } from '../../Hub/visibility';
+import { KIND_ACCENT } from '../../Hub/kindAccent';
+import { useIsPreview } from '../../../contexts/PreviewContext';
+import buttonStyles from '../../../components/Button/Button.module.css';
+import { cx } from '../../../utils/cx';
+import type { SanityHubEntrySummary } from '../../../Types';
+import styles from './BentoSpotlightTeaser.module.css';
+
+type BentoSpotlightTeaserProps = {
+    readonly entries: (SanityHubEntrySummary | null)[];
+};
+
+// The colour that drives both the card accent and the ambient spotlight for an
+// entry — a per-entry accent wins, otherwise the kind default.
+function entryAccent(entry: SanityHubEntrySummary): string {
+    return entry.accentColor ?? KIND_ACCENT[entry.kind] ?? KIND_ACCENT.article;
+}
+
+// DESIGN 07 (combo): Magazine Bento + Accent Spotlight. A bento grid with one
+// large hero cell + smaller satellites. Hovering/focusing any card washes the
+// section in that entry's accent and dims the others.
+function BentoSpotlightTeaser({ entries }: BentoSpotlightTeaserProps) {
+    const isPreview = useIsPreview();
+    const resolvedEntries = filterVisible(
+        entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
+        isPreview,
+    );
+
+    const [active, setActive] = useState<{ slug: string; accent: string } | null>(null);
+
+    if (resolvedEntries.length === 0) return null;
+
+    const heroIndex = Math.max(
+        0,
+        resolvedEntries.findIndex((e) => Boolean(e.coverImage ?? e.sourceThumbnail)),
+    );
+    const hero = resolvedEntries[heroIndex];
+    const rest = resolvedEntries.filter((_, i) => i !== heroIndex);
+    const ordered = [hero, ...rest];
+
+    const renderCard = (entry: SanityHubEntrySummary, isHero: boolean) => {
+        const accent = entryAccent(entry);
+        const dimmed = active !== null && active.slug !== entry.slug;
+        return (
+            <div
+                key={entry.slug}
+                className={cx(styles.cell, isHero && styles.hero, dimmed && styles.dimmed)}
+                onMouseEnter={() => setActive({ slug: entry.slug, accent })}
+                onFocusCapture={() => setActive({ slug: entry.slug, accent })}
+            >
+                <HubCard
+                    title={entry.title}
+                    slug={entry.slug}
+                    kind={entry.kind}
+                    excerpt={entry.excerpt}
+                    coverImage={entry.coverImage}
+                    sourceThumbnail={entry.sourceThumbnail}
+                    durationLabel={entry.durationLabel}
+                    categories={entry.categories}
+                    language={entry.language}
+                    accentColor={entry.accentColor}
+                    hidden={entry.hiddenInProduction}
+                />
+            </div>
+        );
+    };
+
+    return (
+        <div
+            className={cx(styles.teaser, active && styles.lit)}
+            style={{ '--spotlight': active?.accent ?? 'transparent' } as CSSProperties}
+            onMouseLeave={() => setActive(null)}
+            onBlurCapture={() => setActive(null)}
+        >
+            <span className={styles.ambient} aria-hidden="true" />
+            <header className={styles.header}>
+                <div className={styles.titleRow}>
+                    <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
+                    <Text variant="h3">Things Worth Sharing</Text>
+                </div>
+                <hr className={styles.divider} />
+            </header>
+
+            <div className={styles.bento}>
+                {ordered.map((entry, i) => renderCard(entry, i === 0))}
+            </div>
+
+            <StarBorder>
+                <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
+                    Visit the Hub
+                    <FontAwesomeIcon icon={faArrowRight} />
+                </a>
+            </StarBorder>
+        </div>
+    );
+}
+
+export default memo(BentoSpotlightTeaser);

--- a/react-frontend/src/containers/About/variants/MagazineBentoTeaser.module.css
+++ b/react-frontend/src/containers/About/variants/MagazineBentoTeaser.module.css
@@ -1,0 +1,193 @@
+.teaser {
+    background: var(--color-base-900);
+    border-radius: calc(var(--radius) + 6px);
+    padding: clamp(1.25rem, 1rem + 1vw, 2rem);
+    color: #efe9e2;
+    position: relative;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    margin-top: 2rem;
+    box-sizing: border-box;
+}
+
+.kicker {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.1rem;
+    flex-wrap: wrap;
+}
+
+.kickerTitle {
+    font-family: Omnes, sans-serif;
+    font-weight: 600;
+    font-size: clamp(1.6rem, 1.1rem + 2vw, 2.4rem);
+    margin: 0;
+    color: #fff;
+    letter-spacing: -0.01em;
+}
+
+.kickerSub {
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: #c9a98f;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 1.6fr 1fr;
+    grid-auto-rows: 1fr;
+    gap: 14px;
+    min-height: 420px;
+    min-width: 0;
+    max-width: 100%;
+}
+
+.cell {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 1.1rem;
+    background: #20201f;
+    border: 1px solid #ffffff14;
+    transition: var(--transition);
+    isolation: isolate;
+    min-width: 0;
+}
+
+.cell:hover,
+.cell:focus-visible {
+    transform: translateY(-3px);
+    border-color: color-mix(in srgb, var(--a) 60%, transparent);
+    outline: none;
+}
+
+.feat {
+    grid-row: span 2;
+}
+
+.bg {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background-position: center;
+    background-size: cover;
+}
+
+.bg::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 20%, #111 96%);
+}
+
+.tint {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(150deg, color-mix(in srgb, var(--a) 45%, #20201f), #1a1a19);
+}
+
+.rail {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: var(--a);
+    z-index: 2;
+}
+
+.num {
+    position: absolute;
+    top: 0.7rem;
+    right: 0.9rem;
+    font-family: Omnes, sans-serif;
+    font-size: 1.1rem;
+    color: #ffffff66;
+    z-index: 3;
+}
+
+.hiddenPill {
+    position: absolute;
+    top: 0.7rem;
+    left: 0.9rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    background: #00000066;
+    color: #f4e9c9;
+    border: 1px solid #ffffff26;
+    z-index: 3;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--a);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+
+.title {
+    margin: 0 0 0.35rem;
+    color: #fff;
+    font-size: 1.05rem;
+    line-height: 1.2;
+}
+
+.feat .title {
+    font-family: Omnes, sans-serif;
+    font-weight: 600;
+    font-size: clamp(1.4rem, 1rem + 1.6vw, 2rem);
+    line-height: 1.05;
+}
+
+.excerpt {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: #d8cfc6;
+    max-width: 46ch;
+}
+
+.rtl {
+    direction: rtl;
+    text-align: right;
+}
+
+.foot {
+    margin-top: 1.5rem;
+    display: flex;
+    justify-content: center;
+}
+
+.cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+@media (max-width: 720px) {
+    .grid {
+        grid-template-columns: 1fr;
+    }
+
+    .feat {
+        grid-row: auto;
+    }
+}

--- a/react-frontend/src/containers/About/variants/MagazineBentoTeaser.tsx
+++ b/react-frontend/src/containers/About/variants/MagazineBentoTeaser.tsx
@@ -1,0 +1,116 @@
+import { memo } from 'react';
+import type { CSSProperties } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight, faNewspaper, faPodcast, faBookOpen, faTv, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import StarBorder from '../../../components/StarBorder';
+import { filterVisible } from '../../Hub/visibility';
+import { KIND_ACCENT } from '../../Hub/kindAccent';
+import { useIsPreview } from '../../../contexts/PreviewContext';
+import buttonStyles from '../../../components/Button/Button.module.css';
+import { cx } from '../../../utils/cx';
+import type { HubEntryKind, SanityHubEntrySummary } from '../../../Types';
+import styles from './MagazineBentoTeaser.module.css';
+
+type MagazineBentoTeaserProps = {
+    readonly entries: (SanityHubEntrySummary | null)[];
+};
+
+const KIND_META: Record<HubEntryKind, { icon: typeof faNewspaper; label: string }> = {
+    article: { icon: faNewspaper, label: 'Article' },
+    channel: { icon: faTv, label: 'Channel' },
+    podcast: { icon: faPodcast, label: 'Podcast' },
+    read: { icon: faBookOpen, label: 'Reading List' },
+};
+
+// A per-entry accent wins, otherwise the kind default.
+function entryAccent(entry: SanityHubEntrySummary): string {
+    return entry.accentColor ?? KIND_ACCENT[entry.kind] ?? KIND_ACCENT.article;
+}
+
+// DESIGN 01: Magazine Bento. An asymmetric bento grid on a dark editorial
+// canvas — one large featured pick (cover bleed) plus satellite cards, index
+// numerals and accent rails. Deliberately breaks the light, uniform-grid rhythm
+// of the rest of the site.
+function MagazineBentoTeaser({ entries }: MagazineBentoTeaserProps) {
+    const isPreview = useIsPreview();
+    const resolvedEntries = filterVisible(
+        entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
+        isPreview,
+    );
+    if (resolvedEntries.length === 0) return null;
+
+    // The featured cell shows a cover bleed, so prefer the first entry that has
+    // an image; fall back to the first entry otherwise.
+    const heroIndex = Math.max(
+        0,
+        resolvedEntries.findIndex((e) => Boolean(e.coverImage ?? e.sourceThumbnail)),
+    );
+    const hero = resolvedEntries[heroIndex];
+    const rest = resolvedEntries.filter((_, i) => i !== heroIndex);
+    const ordered = [hero, ...rest];
+
+    const renderCell = (entry: SanityHubEntrySummary, index: number, isFeat: boolean) => {
+        const accent = entryAccent(entry);
+        const { icon, label } = KIND_META[entry.kind] ?? KIND_META.article;
+        const image = entry.coverImage ?? entry.sourceThumbnail;
+        const showBg = isFeat && Boolean(image);
+        const isRTL = entry.language === 'ar';
+
+        return (
+            <a
+                key={entry.slug}
+                href={`/hub/${entry.slug}`}
+                className={cx(styles.cell, isFeat && styles.feat)}
+                style={{ '--a': accent } as CSSProperties}
+            >
+                {showBg ? (
+                    <span className={styles.bg} style={{ backgroundImage: `url(${image})` }} aria-hidden="true" />
+                ) : (
+                    <span className={styles.tint} aria-hidden="true" />
+                )}
+                <span className={styles.rail} aria-hidden="true" />
+                <span className={styles.num}>{String(index + 1).padStart(2, '0')}</span>
+                {entry.hiddenInProduction && (
+                    <span className={styles.hiddenPill} title="Hidden from production — visible only in preview mode">
+                        <FontAwesomeIcon icon={faEyeSlash} />
+                        Hidden
+                    </span>
+                )}
+                <span className={styles.badge}>
+                    <FontAwesomeIcon icon={icon} />
+                    {label}
+                </span>
+                <h4 className={cx(styles.title, isRTL && styles.rtl)} dir={isRTL ? 'rtl' : undefined} lang={entry.language}>
+                    {entry.title}
+                </h4>
+                <p className={cx(styles.excerpt, isRTL && styles.rtl)} dir={isRTL ? 'rtl' : undefined} lang={entry.language}>
+                    {entry.excerpt}
+                </p>
+            </a>
+        );
+    };
+
+    return (
+        <div className={styles.teaser}>
+            <div className={styles.kicker}>
+                <h3 className={styles.kickerTitle}>Things Worth Sharing</h3>
+                <span className={styles.kickerSub}>Curated · Updated often</span>
+            </div>
+
+            <div className={styles.grid}>
+                {ordered.map((entry, i) => renderCell(entry, i, i === 0))}
+            </div>
+
+            <div className={styles.foot}>
+                <StarBorder>
+                    <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
+                        Visit the Hub
+                        <FontAwesomeIcon icon={faArrowRight} />
+                    </a>
+                </StarBorder>
+            </div>
+        </div>
+    );
+}
+
+export default memo(MagazineBentoTeaser);

--- a/react-frontend/src/containers/About/variants/PinboardTeaser.module.css
+++ b/react-frontend/src/containers/About/variants/PinboardTeaser.module.css
@@ -1,0 +1,125 @@
+﻿.teaser {
+    composes: container column from '../../../styles/surfaces.module.css';
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 2rem;
+    width: 100%;
+    margin-top: 2rem;
+    /* Faint pinboard texture layered over the section surface. */
+    background-image:
+        radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--color-base-400) 22%, transparent) 1px, transparent 0);
+    background-size: 22px 22px;
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    width: 100%;
+}
+
+.titleRow {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--color-base-700);
+}
+
+.titleIcon {
+    color: var(--color-secondary-500);
+}
+
+.divider {
+    width: 100%;
+    height: 1px;
+    margin: 0;
+    border: none;
+    background-color: var(--color-base-200);
+}
+
+/* The board — a masonry-style scatter so cards of different heights nest like
+   pinned notes. */
+.board {
+    width: 100%;
+    column-gap: 2rem;
+    columns: 3 240px;
+    padding: 0.5rem 0.25rem;
+}
+
+.pin {
+    position: relative;
+    break-inside: avoid;
+    margin: 0 0 2rem;
+    transform: rotate(var(--rot, 0deg));
+    transition: transform 0.25s ease, filter 0.25s ease;
+    filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.16));
+}
+
+.pin:hover,
+.pin:focus-within {
+    transform: rotate(0deg) translateY(-4px) scale(1.02);
+    filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.22));
+    z-index: 2;
+}
+
+.pin > a {
+    max-width: none;
+    width: 100%;
+}
+
+/* A translucent strip of "tape" holding the card to the board. */
+.tape {
+    position: absolute;
+    top: -0.7rem;
+    left: 50%;
+    transform: translateX(-50%) rotate(calc(var(--rot, 0deg) * -1.4));
+    width: 5rem;
+    height: 1.4rem;
+    z-index: 3;
+    background: color-mix(in srgb, var(--color-base-100) 62%, transparent);
+    border-left: 1px solid rgba(255, 255, 255, 0.5);
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    pointer-events: none;
+}
+
+/* Accent-tinted tack pin, using the card's own --entry-accent when set. */
+.tack {
+    position: absolute;
+    top: -0.55rem;
+    left: 1.1rem;
+    z-index: 3;
+    font-size: 0.9rem;
+    color: var(--color-secondary-600);
+    transform: rotate(calc(var(--rot, 0deg) * -2));
+    filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.25));
+    pointer-events: none;
+}
+
+.cta {
+    text-decoration: none;
+    align-self: flex-start;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pin {
+        transition: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .teaser {
+        padding: 1.5rem;
+    }
+
+    .board {
+        columns: 1;
+        column-gap: 0;
+    }
+
+    .pin {
+        transform: rotate(0deg);
+    }
+}
+

--- a/react-frontend/src/containers/About/variants/PinboardTeaser.tsx
+++ b/react-frontend/src/containers/About/variants/PinboardTeaser.tsx
@@ -1,0 +1,79 @@
+import { memo } from 'react';
+import type { CSSProperties } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight, faBookOpen, faThumbtack } from '@fortawesome/free-solid-svg-icons';
+import Text from '../../../components/Text';
+import StarBorder from '../../../components/StarBorder';
+import HubCard from '../../../components/HubCard';
+import { filterVisible } from '../../Hub/visibility';
+import { useIsPreview } from '../../../contexts/PreviewContext';
+import buttonStyles from '../../../components/Button/Button.module.css';
+import { cx } from '../../../utils/cx';
+import type { SanityHubEntrySummary } from '../../../Types';
+import styles from './PinboardTeaser.module.css';
+
+type PinboardTeaserProps = {
+    readonly entries: (SanityHubEntrySummary | null)[];
+};
+
+// Deterministic per-position tilt so the board looks hand-pinned but renders the
+// same every time (no layout jitter between server + client).
+const ROTATIONS = [-2.5, 1.8, -1.4, 2.3, -2, 1.3, -1.7, 2.6, -1.1, 2];
+
+// DESIGN 06: Collage / Pinboard. Featured entries are pinned to a masonry board
+// as slightly-rotated cards with tape + a tack; hovering straightens and lifts.
+function PinboardTeaser({ entries }: PinboardTeaserProps) {
+    const isPreview = useIsPreview();
+    const resolvedEntries = filterVisible(
+        entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
+        isPreview,
+    );
+    if (resolvedEntries.length === 0) return null;
+
+    return (
+        <div className={styles.teaser}>
+            <header className={styles.header}>
+                <div className={styles.titleRow}>
+                    <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
+                    <Text variant="h3">Things Worth Sharing</Text>
+                </div>
+                <hr className={styles.divider} />
+            </header>
+
+            <div className={styles.board}>
+                {resolvedEntries.map((entry, i) => (
+                    <div
+                        className={styles.pin}
+                        key={entry.slug}
+                        style={{ '--rot': `${ROTATIONS[i % ROTATIONS.length]}deg` } as CSSProperties}
+                    >
+                        <span className={styles.tape} aria-hidden="true" />
+                        <FontAwesomeIcon icon={faThumbtack} className={styles.tack} aria-hidden="true" />
+                        <HubCard
+                            title={entry.title}
+                            slug={entry.slug}
+                            kind={entry.kind}
+                            excerpt={entry.excerpt}
+                            coverImage={entry.coverImage}
+                            sourceThumbnail={entry.sourceThumbnail}
+                            durationLabel={entry.durationLabel}
+                            categories={entry.categories}
+                            language={entry.language}
+                            accentColor={entry.accentColor}
+                            hidden={entry.hiddenInProduction}
+                        />
+                    </div>
+                ))}
+            </div>
+
+            <StarBorder>
+                <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
+                    Visit the Hub
+                    <FontAwesomeIcon icon={faArrowRight} />
+                </a>
+            </StarBorder>
+        </div>
+    );
+}
+
+export default memo(PinboardTeaser);

--- a/react-frontend/src/containers/About/variants/RailTeaser.module.css
+++ b/react-frontend/src/containers/About/variants/RailTeaser.module.css
@@ -1,0 +1,166 @@
+﻿.teaser {
+    composes: container column from '../../../styles/surfaces.module.css';
+    align-items: flex-start;
+    gap: 1.25rem;
+    padding: 2rem;
+    width: 100%;
+    margin-top: 2rem;
+    overflow: hidden;
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.85rem;
+    width: 100%;
+}
+
+.titleRow {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--color-base-700);
+}
+
+.titleIcon {
+    color: var(--color-secondary-500);
+}
+
+/* Marquee ticker — a scrolling strip of the featured titles that replaces the
+   static divider with a bit of editorial motion. */
+.marquee {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    padding: 0.5rem 0;
+    border-top: 1px solid var(--color-base-200);
+    border-bottom: 1px solid var(--color-base-200);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+
+.marqueeTrack {
+    display: inline-flex;
+    align-items: center;
+    gap: 2.5rem;
+    white-space: nowrap;
+    will-change: transform;
+    animation: hub-marquee 32s linear infinite;
+}
+
+.marquee:hover .marqueeTrack {
+    animation-play-state: paused;
+}
+
+.marqueeItem {
+    display: inline-flex;
+    align-items: center;
+    gap: 2.5rem;
+    font-size: var(--font-size-sm);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-base-600);
+}
+
+.marqueeDot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--color-secondary-500);
+}
+
+@keyframes hub-marquee {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+}
+
+/* Horizontal rail — a scroll-snapping row of cards. */
+.railWrap {
+    position: relative;
+    width: 100%;
+}
+
+.rail {
+    display: flex;
+    gap: 1.5rem;
+    width: 100%;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding: 0.5rem 0.25rem 1rem;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-base-300) transparent;
+}
+
+.rail::-webkit-scrollbar {
+    height: 8px;
+}
+
+.rail::-webkit-scrollbar-thumb {
+    background-color: var(--color-base-300);
+    border-radius: 999px;
+}
+
+.railItem {
+    flex: 0 0 300px;
+    scroll-snap-align: start;
+    display: flex;
+}
+
+.railItem > * {
+    width: 100%;
+    max-width: none;
+}
+
+.railEnd {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    padding: 0 1rem;
+    scroll-snap-align: end;
+}
+
+/* Edge fades hinting there's more to scroll. */
+.fadeLeft,
+.fadeRight {
+    position: absolute;
+    top: 0;
+    bottom: 1rem;
+    width: 3rem;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.fadeLeft {
+    left: 0;
+    background: linear-gradient(90deg, var(--color-base-50), transparent);
+}
+
+.fadeRight {
+    right: 0;
+    background: linear-gradient(270deg, var(--color-base-50), transparent);
+}
+
+.cta {
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .marqueeTrack {
+        animation: none;
+        transform: translateX(0);
+    }
+}
+
+@media (max-width: 768px) {
+    .teaser {
+        padding: 1.5rem;
+    }
+
+    .railItem {
+        flex-basis: 82%;
+    }
+}
+

--- a/react-frontend/src/containers/About/variants/RailTeaser.module.css
+++ b/react-frontend/src/containers/About/variants/RailTeaser.module.css
@@ -4,6 +4,8 @@
     gap: 1.25rem;
     padding: 2rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     margin-top: 2rem;
     overflow: hidden;
 }
@@ -14,6 +16,8 @@
     align-items: stretch;
     gap: 0.85rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .titleRow {
@@ -32,6 +36,8 @@
 .marquee {
     position: relative;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     overflow: hidden;
     padding: 0.5rem 0;
     border-top: 1px solid var(--color-base-200);
@@ -80,12 +86,16 @@
 .railWrap {
     position: relative;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .rail {
     display: flex;
     gap: 1.5rem;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     padding: 0.5rem 0.25rem 1rem;

--- a/react-frontend/src/containers/About/variants/RailTeaser.tsx
+++ b/react-frontend/src/containers/About/variants/RailTeaser.tsx
@@ -1,0 +1,85 @@
+import { memo } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
+import Text from '../../../components/Text';
+import StarBorder from '../../../components/StarBorder';
+import HubCard from '../../../components/HubCard';
+import { filterVisible } from '../../Hub/visibility';
+import { useIsPreview } from '../../../contexts/PreviewContext';
+import buttonStyles from '../../../components/Button/Button.module.css';
+import { cx } from '../../../utils/cx';
+import type { SanityHubEntrySummary } from '../../../Types';
+import styles from './RailTeaser.module.css';
+
+type RailTeaserProps = {
+    readonly entries: (SanityHubEntrySummary | null)[];
+};
+
+// DESIGN 02: Horizontal Rail + Marquee header. A scrolling ticker headline sits
+// above a horizontal, scroll-snapping rail of cards.
+function RailTeaser({ entries }: RailTeaserProps) {
+    const isPreview = useIsPreview();
+    const resolvedEntries = filterVisible(
+        entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
+        isPreview,
+    );
+    if (resolvedEntries.length === 0) return null;
+
+    const tickerItems = resolvedEntries.map((entry) => entry.title);
+    const marqueeItems = [...tickerItems, ...tickerItems];
+
+    return (
+        <div className={styles.teaser}>
+            <header className={styles.header}>
+                <div className={styles.titleRow}>
+                    <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
+                    <Text variant="h3">Things Worth Sharing</Text>
+                </div>
+                <div className={styles.marquee} aria-hidden="true">
+                    <div className={styles.marqueeTrack}>
+                        {marqueeItems.map((title, i) => (
+                            <span className={styles.marqueeItem} key={`${title}-${i}`}>
+                                <span className={styles.marqueeDot} />
+                                {title}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            </header>
+
+            <div className={styles.railWrap}>
+                <div className={styles.rail}>
+                    {resolvedEntries.map((entry) => (
+                        <div className={styles.railItem} key={entry.slug}>
+                            <HubCard
+                                title={entry.title}
+                                slug={entry.slug}
+                                kind={entry.kind}
+                                excerpt={entry.excerpt}
+                                coverImage={entry.coverImage}
+                                sourceThumbnail={entry.sourceThumbnail}
+                                durationLabel={entry.durationLabel}
+                                categories={entry.categories}
+                                language={entry.language}
+                                accentColor={entry.accentColor}
+                                hidden={entry.hiddenInProduction}
+                            />
+                        </div>
+                    ))}
+                    <div className={styles.railEnd}>
+                        <StarBorder>
+                            <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
+                                Visit the Hub
+                                <FontAwesomeIcon icon={faArrowRight} />
+                            </a>
+                        </StarBorder>
+                    </div>
+                </div>
+                <span className={styles.fadeLeft} aria-hidden="true" />
+                <span className={styles.fadeRight} aria-hidden="true" />
+            </div>
+        </div>
+    );
+}
+
+export default memo(RailTeaser);


### PR DESCRIPTION
Comparison scaffold (not intended to merge as-is). Renders the 'Things Worth Sharing' section **three times on one page**, each behind a labeled banner: Design 02 (Rail + Marquee), Design 06 (Pinboard), Design 07 (Bento + Spotlight). Variant components live under 'src/containers/About/variants/'. Once a winner is chosen, the showcase wrapper is replaced by the single chosen variant. Includes the About projection fix (accentColor/language/hiddenInProduction). Sibling design PRs: #133, #134, #135.