### PR TITLE
Make Magazine Bento the Hub teaser design

### DIFF
--- a/react-frontend/src/APIs/Sanity/about.ts
+++ b/react-frontend/src/APIs/Sanity/about.ts
@@ -12,6 +12,7 @@ const getAboutPage = async () => {
             "slug": slug.current,
             kind,
             excerpt,
+            language,
             "coverImage": coverImage.asset->url,
             sourceThumbnail,
             sourceName,
@@ -19,6 +20,8 @@ const getAboutPage = async () => {
             externalUrl,
             publishedAt,
             featured,
+            hiddenInProduction,
+            "accentColor": accent.hex,
             "categories": categories[]->{ title, "slug": slug.current }
         },
     }`;

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -1,50 +1,193 @@
 .teaser {
-    composes: container column from '../../styles/surfaces.module.css';
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 2rem;
+    background: var(--color-base-900);
+    border-radius: calc(var(--radius) + 6px);
+    padding: clamp(1.25rem, 1rem + 1vw, 2rem);
+    color: #efe9e2;
+    position: relative;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     margin-top: 2rem;
+    box-sizing: border-box;
 }
 
-.header {
+.kicker {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.75rem;
-    width: 100%;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.1rem;
+    flex-wrap: wrap;
 }
 
-.titleRow {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    color: var(--color-base-700);
-}
-
-.titleIcon {
-    color: var(--color-secondary-500);
-}
-
-.divider {
-    width: 100%;
-    height: 1px;
+.kickerTitle {
+    font-family: Omnes, sans-serif;
+    font-weight: 600;
+    font-size: clamp(1.6rem, 1.1rem + 2vw, 2.4rem);
     margin: 0;
-    border: none;
-    background-color: var(--color-base-200);
+    color: #fff;
+    letter-spacing: -0.01em;
+}
+
+.kickerSub {
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: #c9a98f;
 }
 
 .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 1.5rem;
-    width: 100%;
+    grid-template-columns: 1.6fr 1fr;
+    grid-auto-rows: 1fr;
+    gap: 14px;
+    min-height: 420px;
+    min-width: 0;
+    max-width: 100%;
 }
 
-.grid > * {
-    max-width: none;
+.cell {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 1.1rem;
+    background: #20201f;
+    border: 1px solid #ffffff14;
+    transition: var(--transition);
+    isolation: isolate;
+    min-width: 0;
+}
+
+.cell:hover,
+.cell:focus-visible {
+    transform: translateY(-3px);
+    border-color: color-mix(in srgb, var(--a) 60%, transparent);
+    outline: none;
+}
+
+.feat {
+    grid-row: span 2;
+}
+
+.bg {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background-position: center;
+    background-size: cover;
+}
+
+.bg::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 20%, #111 96%);
+}
+
+.tint {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(150deg, color-mix(in srgb, var(--a) 45%, #20201f), #1a1a19);
+}
+
+.rail {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: var(--a);
+    z-index: 2;
+}
+
+.num {
+    position: absolute;
+    top: 0.7rem;
+    right: 0.9rem;
+    font-family: Omnes, sans-serif;
+    font-size: 1.1rem;
+    color: #ffffff66;
+    z-index: 3;
+}
+
+.hiddenPill {
+    position: absolute;
+    top: 0.7rem;
+    left: 0.9rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    background: #00000066;
+    color: #f4e9c9;
+    border: 1px solid #ffffff26;
+    z-index: 3;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--a);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+
+.title {
+    margin: 0 0 0.35rem;
+    color: #fff;
+    font-size: 1.05rem;
+    line-height: 1.2;
+}
+
+.feat .title {
+    font-family: Omnes, sans-serif;
+    font-weight: 600;
+    font-size: clamp(1.4rem, 1rem + 1.6vw, 2rem);
+    line-height: 1.05;
+}
+
+.excerpt {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: #d8cfc6;
+    max-width: 46ch;
+}
+
+.rtl {
+    direction: rtl;
+    text-align: right;
+}
+
+.foot {
+    margin-top: 1.5rem;
+    display: flex;
+    justify-content: center;
 }
 
 .cta {
-    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+@media (max-width: 720px) {
+    .grid {
+        grid-template-columns: 1fr;
+    }
+
+    .feat {
+        grid-row: auto;
+    }
 }

--- a/react-frontend/src/containers/About/HubTeaser.tsx
+++ b/react-frontend/src/containers/About/HubTeaser.tsx
@@ -1,74 +1,116 @@
 import { memo } from 'react';
+import type { CSSProperties } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight, faBookOpen } from '@fortawesome/free-solid-svg-icons';
-import Text from '../../components/Text';
+import { faArrowRight, faNewspaper, faPodcast, faBookOpen, faTv, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import StarBorder from '../../components/StarBorder';
-import HubCard from '../../components/HubCard';
 import { filterVisible } from '../Hub/visibility';
+import { KIND_ACCENT } from '../Hub/kindAccent';
 import { useIsPreview } from '../../contexts/PreviewContext';
 import buttonStyles from '../../components/Button/Button.module.css';
 import { cx } from '../../utils/cx';
-import type { SanityHubEntrySummary } from '../../Types';
+import type { HubEntryKind, SanityHubEntrySummary } from '../../Types';
 import styles from './HubTeaser.module.css';
 
 type HubTeaserProps = {
     readonly entries: (SanityHubEntrySummary | null)[];
 };
 
-// Small "Things Worth Sharing" teaser on the About/home page — surfaces a
-// hand-curated list of Hub entries (via about.featuredInAbout, in author order)
-// with a CTA to the full /hub index. Renders nothing when no entries are
-// curated yet. The responsive grid wraps to as many rows as needed, so there's
-// no fixed entry count.
+const KIND_META: Record<HubEntryKind, { icon: typeof faNewspaper; label: string }> = {
+    article: { icon: faNewspaper, label: 'Article' },
+    channel: { icon: faTv, label: 'Channel' },
+    podcast: { icon: faPodcast, label: 'Podcast' },
+    read: { icon: faBookOpen, label: 'Reading List' },
+};
+
+// A per-entry accent wins, otherwise the kind default.
+function entryAccent(entry: SanityHubEntrySummary): string {
+    return entry.accentColor ?? KIND_ACCENT[entry.kind] ?? KIND_ACCENT.article;
+}
+
+// "Things Worth Sharing" home teaser — Magazine Bento. An asymmetric bento grid
+// on a dark editorial canvas: one large featured pick (cover bleed) plus
+// satellite cards, index numerals and per-entry accent rails. Deliberately
+// breaks the light, uniform-grid rhythm of the rest of the site.
 function HubTeaser({ entries }: HubTeaserProps) {
     const isPreview = useIsPreview();
-    // Entries come from dereferencing `featuredInAbout` refs; a stale/broken
-    // reference (e.g. the target was deleted, or is temporarily unreadable)
-    // resolves to `null` in the array rather than being dropped, so guard
-    // against that instead of crashing the whole page. Hidden entries are also
-    // filtered unless preview mode is on.
     const resolvedEntries = filterVisible(
         entries.filter((entry): entry is SanityHubEntrySummary => Boolean(entry)),
         isPreview,
     );
     if (resolvedEntries.length === 0) return null;
 
+    // The featured cell shows a cover bleed, so prefer the first entry that has
+    // an image; fall back to the first entry otherwise.
+    const heroIndex = Math.max(
+        0,
+        resolvedEntries.findIndex((e) => Boolean(e.coverImage ?? e.sourceThumbnail)),
+    );
+    const hero = resolvedEntries[heroIndex];
+    const rest = resolvedEntries.filter((_, i) => i !== heroIndex);
+    const ordered = [hero, ...rest];
+
+    const renderCell = (entry: SanityHubEntrySummary, index: number, isFeat: boolean) => {
+        const accent = entryAccent(entry);
+        const { icon, label } = KIND_META[entry.kind] ?? KIND_META.article;
+        const image = entry.coverImage ?? entry.sourceThumbnail;
+        const showBg = isFeat && Boolean(image);
+        const isRTL = entry.language === 'ar';
+
+        return (
+            <a
+                key={entry.slug}
+                href={`/hub/${entry.slug}`}
+                className={cx(styles.cell, isFeat && styles.feat)}
+                style={{ '--a': accent } as CSSProperties}
+            >
+                {showBg ? (
+                    <span className={styles.bg} style={{ backgroundImage: `url(${image})` }} aria-hidden="true" />
+                ) : (
+                    <span className={styles.tint} aria-hidden="true" />
+                )}
+                <span className={styles.rail} aria-hidden="true" />
+                <span className={styles.num}>{String(index + 1).padStart(2, '0')}</span>
+                {entry.hiddenInProduction && (
+                    <span className={styles.hiddenPill} title="Hidden from production — visible only in preview mode">
+                        <FontAwesomeIcon icon={faEyeSlash} />
+                        Hidden
+                    </span>
+                )}
+                <span className={styles.badge}>
+                    <FontAwesomeIcon icon={icon} />
+                    {label}
+                </span>
+                <h4 className={cx(styles.title, isRTL && styles.rtl)} dir={isRTL ? 'rtl' : undefined} lang={entry.language}>
+                    {entry.title}
+                </h4>
+                <p className={cx(styles.excerpt, isRTL && styles.rtl)} dir={isRTL ? 'rtl' : undefined} lang={entry.language}>
+                    {entry.excerpt}
+                </p>
+            </a>
+        );
+    };
+
     return (
         <div className={styles.teaser}>
-            <header className={styles.header}>
-                <div className={styles.titleRow}>
-                    <FontAwesomeIcon icon={faBookOpen} size="xl" className={styles.titleIcon} />
-                    <Text variant="h3">Things Worth Sharing</Text>
-                </div>
-                <hr className={styles.divider} />
-            </header>
-            <div className={styles.grid}>
-                {resolvedEntries.map((entry) => (
-                    <HubCard
-                        key={entry.slug}
-                        title={entry.title}
-                        slug={entry.slug}
-                        kind={entry.kind}
-                        excerpt={entry.excerpt}
-                        coverImage={entry.coverImage}
-                        sourceThumbnail={entry.sourceThumbnail}
-                        durationLabel={entry.durationLabel}
-                        categories={entry.categories}
-                        language={entry.language}
-                        accentColor={entry.accentColor}
-                        hidden={entry.hiddenInProduction}
-                    />
-                ))}
+            <div className={styles.kicker}>
+                <h3 className={styles.kickerTitle}>Things Worth Sharing</h3>
+                <span className={styles.kickerSub}>Curated · Updated often</span>
             </div>
-            <StarBorder>
-                <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
-                    Visit the Hub
-                    <FontAwesomeIcon icon={faArrowRight} />
-                </a>
-            </StarBorder>
+
+            <div className={styles.grid}>
+                {ordered.map((entry, i) => renderCell(entry, i, i === 0))}
+            </div>
+
+            <div className={styles.foot}>
+                <StarBorder>
+                    <a href="/hub" className={cx(buttonStyles.button, buttonStyles.md, buttonStyles.pointer, styles.cta)}>
+                        Visit the Hub
+                        <FontAwesomeIcon icon={faArrowRight} />
+                    </a>
+                </StarBorder>
+            </div>
         </div>
     );
 }
 
 export default memo(HubTeaser);
-


### PR DESCRIPTION
## What

Replaces the "Things Worth Sharing" home teaser with the chosen **Magazine Bento** design — an asymmetric bento grid on a dark editorial canvas:

- One large **cover-bleed featured pick** (spans 2 rows; picks the first entry with an image)
- Satellite cards with **index numerals** and per-entry **accent rails**
- "Curated · Updated often" kicker
- Deliberately breaks the light, uniform-grid rhythm of the rest of the site

## Behavior preserved

- `filterVisible` + preview gating (hidden/dummy entries only show in dev/preview)
- RTL rendering for Arabic entries
- Per-entry accents (falls back to kind default)
- "Hidden" pill on production-hidden entries

## Also

- Fixes the About GROQ projection to fetch `language`, `hiddenInProduction`, and `accentColor` (`accent.hex`) so those per-entry behaviors actually reach the teaser.

## Validation

- `tsc --noEmit` ✅
- `eslint` ✅
- `vike build` ✅
- `vitest run` — 39/39 ✅

This was picked from a 4-way design showcase (branches `design/hub-teaser-*`), which will be retired once this merges.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>