### PR TITLE
Build freshness (useCdn:false) + mobile layout fixes

### DIFF
--- a/react-frontend/pages/Layout.module.css
+++ b/react-frontend/pages/Layout.module.css
@@ -3,6 +3,14 @@
     background-color: var(--color-base-100);
     min-height: 100vh;
     color: var(--color-base-700);
+    /* Guard against decorative elements that intentionally overflow their own
+       box (e.g. the About avatar's rotating CircularText ring, whose absolutely
+       positioned, rotated letter spans have bounding boxes wider than the ring
+       itself). On narrow viewports those phantom boxes would otherwise push the
+       document past 100vw, producing a horizontal scroll with no visible
+       content ("content shifted right"). `clip` — not `hidden` — is used so no
+       scroll container is created and the sticky navbar keeps working. */
+    overflow-x: clip;
 }
 
 .page *::selection {
@@ -13,7 +21,9 @@
 .inner {
     max-width: 1255px;
     margin: 0 auto;
-    padding: 0 1rem;
+    /* Top padding matches the Navbar's sticky `top: 20px` so the bar sits in
+       the same place at rest as it does once stuck — no jump on first scroll. */
+    padding: 20px 1rem 0;
 }
 
 .skipLink {
@@ -31,6 +41,15 @@
 .skipLink:focus {
     left: var(--space-3);
     top: var(--space-3);
+}
+
+/* Uniform breathing room between the sticky navbar and page content. This is
+   the single, intentional place for page top/bottom spacing (previously a
+   `padding-top: 70px` hack lived in ContainerWrap). Decorative overflow such
+   as the About avatar's ring reserves its own halo locally, so this value is
+   about rhythm, not collision-avoidance. */
+.main {
+    padding-block: var(--space-6);
 }
 
 .main:focus {

--- a/react-frontend/pages/hub/@slug/HubEntryPage.module.css
+++ b/react-frontend/pages/hub/@slug/HubEntryPage.module.css
@@ -3,4 +3,16 @@
     flex-direction: column;
     align-items: stretch;
     gap: 1rem;
+    /* The shared .main shell adds var(--space-6) top padding for uniform page
+       spacing. On this page the first element is a small breadcrumb, so that
+       large gap above it looks unbalanced against the 1rem gap below it. Pull
+       the column up so the breadcrumb sits 1rem below the navbar, matching the
+       inter-section gap. Token math keeps it in sync with .main's padding. */
+    margin-top: calc(1rem - var(--space-6));
+    /* This column is a grid item in the ContainerWrap shell. Grid/flex items
+       default to min-width: auto, so a non-wrapping child (e.g. a code block's
+       <pre>) can force the whole column wider than the viewport on mobile.
+       min-width: 0 lets it shrink to the reading column; long code then scrolls
+       inside its own card. */
+    min-width: 0;
 }

--- a/react-frontend/src/APIs/Sanity/client.ts
+++ b/react-frontend/src/APIs/Sanity/client.ts
@@ -6,7 +6,15 @@ const sanityClient = createClient({
     projectId: import.meta.env.VITE_SANITY_PROJECT_ID ?? 'h48br789',
     dataset: import.meta.env.VITE_SANITY_DATASET ?? 'production',
     apiVersion: import.meta.env.VITE_SANITY_API_VERSION ?? '2022-03-07',
-    useCdn: true,
+    // The site is a pure static prerender (Vike SSG): every query runs at BUILD
+    // time via +data.ts / onBeforePrerenderStart, never in the browser. The
+    // Sanity API CDN is eventually consistent (stale up to ~60s after publish),
+    // so with useCdn:true a webhook-triggered rebuild that starts seconds after
+    // a publish can race the CDN and bake stale content. useCdn:false hits the
+    // live API, guaranteeing the build always gets the freshest data — no wait
+    // or debounce needed. (There is no runtime/browser cost since nothing
+    // fetches Sanity client-side.)
+    useCdn: false,
 })
 
 export default sanityClient;

--- a/react-frontend/src/components/ContainerWrap.module.css
+++ b/react-frontend/src/components/ContainerWrap.module.css
@@ -1,6 +1,8 @@
+/* This wrapper exists purely for the page-enter/leave slide transition. Page
+   spacing (breathing room under the sticky navbar) lives on `.main` in the
+   layout, not here — see pages/Layout.module.css. The grid + centering keeps
+   the animated child laid out consistently during the transition. */
 .container {
     display: grid;
     align-items: center;
-    padding-top: 70px;
-    padding-bottom: 30px;
 }

--- a/react-frontend/src/containers/About/HubTeaser.module.css
+++ b/react-frontend/src/containers/About/HubTeaser.module.css
@@ -180,6 +180,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
+    text-decoration: none;
 }
 
 @media (max-width: 720px) {

--- a/react-frontend/src/containers/About/Image/Image.module.css
+++ b/react-frontend/src/containers/About/Image/Image.module.css
@@ -2,10 +2,18 @@
     /* Scales down on narrow viewports so the ring (which extends beyond
        this box) never gets close to the screen edges. */
     --avatar-size: clamp(200px, 58vw, 320px);
+    /* The CircularText ring is `--avatar-size * 1.24` centered on this frame,
+       so it overflows every side by ~`--avatar-size * 0.12` (plus ~half a
+       glyph). Reserve that halo as margin where a collision can happen — above
+       (the sticky navbar) and to the sides (horizontal container overflow).
+       The bottom is left to the container's normal `gap`, so the ring's
+       harmless decorative overflow tucks into that gap instead of pushing the
+       name far away. */
+    --avatar-halo: calc(var(--avatar-size) * 0.12 + var(--space-2));
     width: var(--avatar-size);
     height: var(--avatar-size);
     position: relative;
-    margin-right: 10px;
+    margin: var(--avatar-halo) var(--avatar-halo) 0;
 }
 
 .ring {


### PR DESCRIPTION
## Summary

Two related fronts, both verified locally (tsc ✅, build ✅ 24 docs prerendered):

### Build freshness
- Use the live Sanity API (`useCdn: false`) for the static build so every trigger (git push, deploy hook, scheduled rebuild) reads fresh content instead of a stale CDN snapshot.

### Mobile layout & spacing
- **Layout shell:** guard mobile horizontal overflow with `overflow-x: clip` on `.page` (preserves the sticky navbar), move uniform page spacing onto `.main` (`padding-block`), rest the navbar at 20px via `.inner` padding-top.
- **ContainerWrap:** drop the hard-coded 70px/30px padding hack now that spacing lives on `.main`.
- **Hub entry page:** add `min-width: 0` so a non-wrapping code block `<pre>` no longer forces the grid column past the viewport on mobile (long code now scrolls inside its own card); pull the column up so the breadcrumb sits 1rem below the navbar, matching the inter-section gap.
- **About avatar:** reserve the decorative ring halo locally (asymmetric margin) so it no longer collides with the navbar or over-separates from the name.
- **About HubTeaser:** remove the underline on the "Visit the Hub" CTA.

Verified at 400×764 (Pixel 7): no horizontal overflow across home, hub, hub entry (EN + AR), and category routes.