### PR TITLE
Tighten page top spacing + clear rotated section titles

### DIFF
--- a/react-frontend/pages/Layout.module.css
+++ b/react-frontend/pages/Layout.module.css
@@ -47,9 +47,12 @@
    the single, intentional place for page top/bottom spacing (previously a
    `padding-top: 70px` hack lived in ContainerWrap). Decorative overflow such
    as the About avatar's ring reserves its own halo locally, so this value is
-   about rhythm, not collision-avoidance. */
+   about rhythm, not collision-avoidance. The top gap is intentionally tight
+   (1rem) so it matches the gap between page sections; the bottom keeps a
+   larger footer margin. */
 .main {
-    padding-block: var(--space-6);
+    padding-top: 1rem;
+    padding-bottom: var(--space-6);
 }
 
 .main:focus {

--- a/react-frontend/pages/hub/@slug/HubEntryPage.module.css
+++ b/react-frontend/pages/hub/@slug/HubEntryPage.module.css
@@ -3,12 +3,6 @@
     flex-direction: column;
     align-items: stretch;
     gap: 1rem;
-    /* The shared .main shell adds var(--space-6) top padding for uniform page
-       spacing. On this page the first element is a small breadcrumb, so that
-       large gap above it looks unbalanced against the 1rem gap below it. Pull
-       the column up so the breadcrumb sits 1rem below the navbar, matching the
-       inter-section gap. Token math keeps it in sync with .main's padding. */
-    margin-top: calc(1rem - var(--space-6));
     /* This column is a grid item in the ContainerWrap shell. Grid/flex items
        default to min-width: auto, so a non-wrapping child (e.g. a code block's
        <pre>) can force the whole column wider than the viewport on mobile.

--- a/react-frontend/src/styles/section.module.css
+++ b/react-frontend/src/styles/section.module.css
@@ -4,4 +4,8 @@
     align-items: stretch;
     justify-content: center;
     gap: 2rem;
+    /* These pages open with a SectionTitle whose highlighted label is rotated
+       (-3deg), so its top corner rises above its box. Add a little clearance so
+       that decoration doesn't crowd the sticky navbar at the tight page top. */
+    padding-top: var(--space-2);
 }


### PR DESCRIPTION
## Summary

Follow-up spacing polish on top of the mobile-overflow work. Verified at 400×764 (tsc ✅, build ✅ 24 docs prerendered).

- **Uniform tight top gap:** `.main` now uses `padding-top: 1rem` (was `var(--space-6)`), so every page sits a consistent 1rem below the sticky navbar. The larger bottom padding is kept for footer breathing room.
- **Hub entry page:** dropped the now-redundant negative-margin top hack — the shared `.main` padding already yields the desired 1rem top gap.
- **Section pages:** added `var(--space-2)` top padding to the shared `.section` wrapper so the `SectionTitle`'s rotated (`-3deg`) highlight has clearance from the navbar on education / experience / skills / projects / contacts / hub pages (~24px there, while title-less pages like About/home and the hub entry stay at the tight 16px).